### PR TITLE
Add colliderGroups

### DIFF
--- a/Sources/VRMKit/VRM/VRM.swift
+++ b/Sources/VRMKit/VRM/VRM.swift
@@ -149,6 +149,7 @@ public extension VRM {
 
     struct SecondaryAnimation: Codable {
         public let boneGroups: [BoneGroup]
+        public let colliderGroups: [ColliderGroup]
         public struct BoneGroup: Codable {
             public let bones: [Int]
             public let center: Int
@@ -171,6 +172,16 @@ public extension VRM {
                 gravityPower = try decodeDouble(key: .gravityPower, container: container)
                 hitRadius = try decodeDouble(key: .hitRadius, container: container)
                 stiffiness = try decodeDouble(key: .stiffiness, container: container)
+            }
+        }
+        
+        public struct ColliderGroup: Codable {
+            public let node: Int
+            public let colliders: [Collider]
+            
+            public struct Collider: Codable {
+                public let offset: Vector3
+                public let radius: Double
             }
         }
     }

--- a/Tests/VRMKit/VRMKitTests.swift
+++ b/Tests/VRMKit/VRMKitTests.swift
@@ -81,7 +81,7 @@ class VRMTests: XCTestCase {
         XCTAssertEqual(vrm.firstPerson.meshAnnotations[0].mesh, 0)
     }
 
-    func testSecondaryAnimation() {
+    func testSecondaryAnimationBoneGroups() {
         let target = vrm.secondaryAnimation.boneGroups[0]
         XCTAssertEqual(target.bones, [41, 49, 57, 59, 61])
         XCTAssertEqual(target.center, -1)
@@ -94,5 +94,14 @@ class VRMTests: XCTestCase {
         XCTAssertEqual(target.gravityPower, 0.0)
         XCTAssertEqual(target.hitRadius, 0.01)
         XCTAssertEqual(target.stiffiness, 0.65)
+    }
+    
+    func testSecondaryAnimationColliderGroups() {
+        let target = vrm.secondaryAnimation.colliderGroups[0]
+        XCTAssertEqual(target.node, 34)
+        XCTAssertEqual(target.colliders[0].offset.x, 0.0)
+        XCTAssertEqual(target.colliders[0].offset.y, 0.05)
+        XCTAssertEqual(target.colliders[0].offset.z, 0.0)
+        XCTAssertEqual(target.colliders[0].radius, 0.09)
     }
 }


### PR DESCRIPTION
Add ColliderGroups to secondary animations.

https://github.com/vrm-c/vrm-specification/blob/master/specification/0.0/README.ja.md#揺れモノ当たり判定設定jsonextensionsvrmsecondaryanimationcollidergroups