### PR TITLE
[WIP] Add options for preview

### DIFF
--- a/Sources/VRMSceneKit/GLTF2SCN/SCNNode+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNNode+GLTF.swift
@@ -19,7 +19,7 @@ extension SCNNode {
             let meshNode = try loader.mesh(withMeshIndex: mesh)
             addChildNode(meshNode)
 
-            if let skinIndex = node.skin, let skin = skins?[skinIndex] {
+            if let skinIndex = node.skin, let skin = skins?[skinIndex], loader.options.needsSkinner {
                 let joints = try skin.joints.map(loader.node)
                 let ibm = try skin.inverseBindMatrices.map(loader.inverseBindMatrix)
                 let skeleton = try skin.skeleton.map(loader.node)
@@ -88,7 +88,7 @@ extension SCNNode {
                 }
             }
 
-            if let targets = primitive.targets, !targets.isEmpty {
+            if let targets = primitive.targets, !targets.isEmpty, loader.options.needsMopher {
                 morpher = try SCNMorpher(primitiveTargets: targets, loader: loader)
                 node.morpher = morpher
 //                let path = "childNodes[0].childNodes[\(primitiveIndex)].morpher.weights[\(index)]"

--- a/Sources/VRMSceneKit/GLTF2SCN/UIImage+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/UIImage+GLTF.swift
@@ -10,7 +10,7 @@ import VRMKit
 import UIKit
 
 extension UIImage {
-    convenience init(image: GLTF.Image, relativeTo rootDirectory: URL?, loader: VRMSceneLoader) throws {
+    convenience init(image: GLTF.Image, relativeTo rootDirectory: URL?, loader: VRMSceneLoader, scale: CGFloat) throws {
         let data: Data
         if let uri = image.uri {
             data = try Data(gltfUrlString: uri, relativeTo: rootDirectory)
@@ -19,6 +19,11 @@ extension UIImage {
         } else {
             throw VRMError._dataInconsistent("failed to load images")
         }
-        self.init(cgImage: try UIImage(data: data)?.cgImage ??? ._dataInconsistent("failed to load image"))
+        
+        let cgImage: CGImage? = {
+            guard let ciImage = CIImage(data: data)?.transformed(by: CGAffineTransform(scaleX: scale, y: scale)) else { return nil }
+            return CIContext().createCGImage(ciImage, from: ciImage.extent)
+        }()
+        self.init(cgImage: try cgImage ??? ._dataInconsistent("failed to load image"))
     }
 }

--- a/Sources/VRMSceneKit/VRMSceneLoader+convenience.swift
+++ b/Sources/VRMSceneKit/VRMSceneLoader+convenience.swift
@@ -10,18 +10,18 @@ import VRMKit
 import Foundation
 
 extension VRMSceneLoader {
-    public convenience init(withURL url: URL, rootDirectory: URL? = nil) throws {
+    public convenience init(withURL url: URL, options: VRMSceneLoaderOptions = .default) throws {
         let vrm = try VRMLoader().load(withURL: url)
-        self.init(vrm: vrm, rootDirectory: rootDirectory)
+        self.init(vrm: vrm, options: options)
     }
 
-    public convenience init(named: String, rootDirectory: URL? = nil) throws {
+    public convenience init(named: String, options: VRMSceneLoaderOptions = .default) throws {
         let vrm = try VRMLoader().load(named: named)
-        self.init(vrm: vrm, rootDirectory: rootDirectory)
+        self.init(vrm: vrm, options: options)
     }
 
-    public convenience init(withData data: Data, rootDirectory: URL? = nil) throws {
+    public convenience init(withData data: Data, options: VRMSceneLoaderOptions = .default) throws {
         let vrm = try VRMLoader().load(withData: data)
-        self.init(vrm: vrm, rootDirectory: rootDirectory)
+        self.init(vrm: vrm, options: options)
     }
 }

--- a/Sources/VRMSceneKit/VRMSceneLoader.swift
+++ b/Sources/VRMSceneKit/VRMSceneLoader.swift
@@ -17,7 +17,7 @@ public struct VRMSceneLoaderOptions {
     public let needsMopher: Bool
     public let rootDirectory: URL?
     
-    init(textureScale: CGFloat = 1.0, needsSkinner: Bool = true, needsMopher: Bool = true, rootDirectory: URL? = nil) {
+    public init(textureScale: CGFloat = 1.0, needsSkinner: Bool = true, needsMopher: Bool = true, rootDirectory: URL? = nil) {
         self.textureScale = textureScale
         self.needsSkinner = needsSkinner
         self.needsMopher = needsMopher


### PR DESCRIPTION
一部の機能をロードしない&texture圧縮をするオプションを追加しました。
経緯としては、QuickLookExtensionでVRMのプレビューを対応させるためにQLPreviewingControllerを実装していましたが、100MBのメモリ使用上限があったためです。

<img width="849" alt="スクリーンショット 2020-02-19 15 49 34" src="https://user-images.githubusercontent.com/2066707/74808956-6e75be80-532f-11ea-9685-c9027fdd150d.png">

現状のExampleでは160MB程度を消費しますが、options = .previewを指定することで90MB程度に抑えることができます。

Before
<img width="270" alt="スクリーンショット 2020-02-19 15 43 51" src="https://user-images.githubusercontent.com/2066707/74809053-a3821100-532f-11ea-9b04-e7f7e5880d4d.png">


After
<img width="274" alt="スクリーンショット 2020-02-19 15 43 30" src="https://user-images.githubusercontent.com/2066707/74809057-a5e46b00-532f-11ea-850f-230aa6da9d47.png">
