### PR TITLE
Add metadata-only VRM loading

### DIFF
--- a/Sources/VRMKit/BinaryGLTF.swift
+++ b/Sources/VRMKit/BinaryGLTF.swift
@@ -32,6 +32,26 @@ package extension BinaryGLTF {
 }
 
 extension BinaryGLTF {
+    public init(jsonDataOnly data: Data) throws {
+        var offset = MemoryLayout<UInt32>.size // skip `magic`
+        let rawVersion: UInt32 = try read(data, offset: &offset, size: MemoryLayout<UInt32>.size)
+        guard let version = GLTF.Version(rawValue: rawVersion), version == .two else {
+            throw VRMError.notSupportedVersion(rawVersion)
+        }
+        self.version = version
+
+        _ = try read(data, offset: &offset, size: MemoryLayout<UInt32>.size) as UInt32
+        let chunk0Length: UInt32 = try read(data, offset: &offset, size: MemoryLayout<UInt32>.size)
+        let chunk0Type: UInt32 = try read(data, offset: &offset, size: MemoryLayout<UInt32>.size)
+        guard ChunkType(rawValue: chunk0Type) == .json else {
+            throw VRMError.notSupportedChunkType(chunk0Type)
+        }
+        let jsonData = read(data, offset: &offset, size: Int(chunk0Length))
+        let decoder = JSONDecoder()
+        self.jsonData = try decoder.decode(GLTF.self, from: jsonData)
+        binaryBuffer = nil
+    }
+
     public init(data: Data) throws {
         var offset = MemoryLayout<UInt32>.size // skip `magic`
         let rawVersion: UInt32 = try read(data, offset: &offset, size: MemoryLayout<UInt32>.size)

--- a/Sources/VRMKit/VRMLoader.swift
+++ b/Sources/VRMKit/VRMLoader.swift
@@ -22,6 +22,26 @@ open class VRMLoader {
         return try VRM(data: data)
     }
 
+    open func loadMeta(withURL url: URL) throws -> VRM0.Meta {
+        let data = try Data(contentsOf: url)
+        return try loadMeta(withData: data)
+    }
+
+    open func loadMeta(withData data: Data) throws -> VRM0.Meta {
+        let gltf = try BinaryGLTF(jsonDataOnly: data)
+        let rawExtensions = try gltf.jsonData.extensions ??? .keyNotFound("extensions")
+        let extensions = try rawExtensions.value as? [String: [String: Any]] ??? .dataInconsistent("extension type mismatch")
+        let decoder = DictionaryDecoder()
+
+        if let vrm1 = extensions["VRMC_vrm"] {
+            let meta = try decoder.decode(VRM1.Meta.self, from: try vrm1["meta"] ??? .keyNotFound("meta"))
+            return VRM0.Meta(vrm1: meta)
+        }
+
+        let vrm0 = try extensions["VRM"] ??? .keyNotFound("VRM")
+        return try decoder.decode(VRM0.Meta.self, from: try vrm0["meta"] ??? .keyNotFound("meta"))
+    }
+
     open func loadThumbnail(from vrm: VRM) throws -> VRMImage {
         guard let textureIndex = vrm.meta.texture, textureIndex >= 0 else {
             throw VRMError.thumbnailNotFound

--- a/Tests/VRMKitTests/Resources.swift
+++ b/Tests/VRMKitTests/Resources.swift
@@ -5,13 +5,15 @@ enum Resources {
     case seedSan
 
     var data: Data {
+        return try! Data(contentsOf: url)
+    }
+
+    var url: URL {
         switch self {
         case .aliciaSolid:
-            let url = Bundle.module.url(forResource: "AliciaSolid", withExtension: "vrm")!
-            return try! Data(contentsOf: url)
+            return Bundle.module.url(forResource: "AliciaSolid", withExtension: "vrm")!
         case .seedSan:
-            let url = Bundle.module.url(forResource: "Seed-san", withExtension: "vrm")!
-            return try! Data(contentsOf: url)
+            return Bundle.module.url(forResource: "Seed-san", withExtension: "vrm")!
         }
     }
 }

--- a/Tests/VRMKitTests/VRMLoaderTests.swift
+++ b/Tests/VRMKitTests/VRMLoaderTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import VRMKit
+
+class VRMLoaderTests: XCTestCase {
+
+    func testLoadMetaFromVRM0Data() throws {
+        let meta = try VRMLoader().loadMeta(withData: Resources.aliciaSolid.data)
+
+        XCTAssertEqual(meta.title, "Alicia Solid")
+        XCTAssertEqual(meta.author, "DWANGO Co., Ltd.")
+        XCTAssertEqual(meta.texture, 6)
+        XCTAssertEqual(meta.licenseName, "Other")
+    }
+
+    func testLoadMetaFromVRM1Data() throws {
+        let meta = try VRMLoader().loadMeta(withData: Resources.seedSan.data)
+
+        XCTAssertEqual(meta.title, "Seed-san")
+        XCTAssertEqual(meta.author, "VirtualCast, Inc.")
+        XCTAssertEqual(meta.texture, 14)
+        XCTAssertEqual(meta.licenseName, "https://vrm.dev/licenses/1.0/")
+    }
+
+    func testLoadMetaFromURL() throws {
+        let meta = try VRMLoader().loadMeta(withURL: Resources.aliciaSolid.url)
+
+        XCTAssertEqual(meta.title, "Alicia Solid")
+        XCTAssertEqual(meta.author, "DWANGO Co., Ltd.")
+    }
+}


### PR DESCRIPTION
## Summary
- Add a metadata-only BinaryGLTF initializer that decodes the JSON chunk without retaining the BIN chunk
- Add VRMLoader.loadMeta APIs for URL and Data inputs
- Cover VRM0, VRM1, and URL metadata loading with tests

## Tests
- swift test