### PR TITLE
Add VRM1.0 rendering

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		067C5C522AAD6D8B00F8FBB3 /* VRMSceneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 067C5C512AAD6D8B00F8FBB3 /* VRMSceneKit */; };
 		06E1164E2F277C6D00D74CA4 /* VRMKit in Frameworks */ = {isa = PBXBuildFile; productRef = 06E1164D2F277C6D00D74CA4 /* VRMKit */; };
 		06E116502F277C6D00D74CA4 /* VRMRealityKit in Frameworks */ = {isa = PBXBuildFile; productRef = 06E1164F2F277C6D00D74CA4 /* VRMRealityKit */; };
+		06E116552F333D8700D74CA4 /* VRMSceneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 06E116562F333D8700D74CA4 /* VRMSceneKit */; };
 		06E116522F277D1800D74CA4 /* AliciaSolid.vrm in Resources */ = {isa = PBXBuildFile; fileRef = 06E116512F277D1700D74CA4 /* AliciaSolid.vrm */; };
 		06E116542F277ED600D74CA4 /* AliciaSolid.vrm in Resources */ = {isa = PBXBuildFile; fileRef = 06E116512F277D1700D74CA4 /* AliciaSolid.vrm */; };
 		06F0BD792AAD81A40089488C /* WatchExample Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 06F0BD6C2AAD81A30089488C /* WatchExample Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -106,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06E116552F333D8700D74CA4 /* VRMSceneKit in Frameworks */,
 				06E116502F277C6D00D74CA4 /* VRMRealityKit in Frameworks */,
 				06E1164E2F277C6D00D74CA4 /* VRMKit in Frameworks */,
 			);
@@ -212,6 +214,7 @@
 			packageProductDependencies = (
 				06E1164D2F277C6D00D74CA4 /* VRMKit */,
 				06E1164F2F277C6D00D74CA4 /* VRMRealityKit */,
+				06E116562F333D8700D74CA4 /* VRMSceneKit */,
 			);
 			productName = MacExample;
 			productReference = 06E116422F277AEA00D74CA4 /* MacExample.app */;
@@ -865,6 +868,10 @@
 		06E1164F2F277C6D00D74CA4 /* VRMRealityKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = VRMRealityKit;
+		};
+		06E116562F333D8700D74CA4 /* VRMSceneKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = VRMSceneKit;
 		};
 		06F0BD7E2AAD82120089488C /* VRMKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/MacExample.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/MacExample.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "06E116412F277AEA00D74CA4"
+               BuildableName = "MacExample.app"
+               BlueprintName = "MacExample"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06E116412F277AEA00D74CA4"
+            BuildableName = "MacExample.app"
+            BlueprintName = "MacExample"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06E116412F277AEA00D74CA4"
+            BuildableName = "MacExample.app"
+            BlueprintName = "MacExample"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/MacExample/ContentView.swift
+++ b/Example/MacExample/ContentView.swift
@@ -7,59 +7,139 @@
 //
 
 import SwiftUI
+import SceneKit
 import RealityKit
+internal import VRMSceneKit
 internal import VRMRealityKit
 internal import Combine
 internal import VRMKit
 
 struct ContentView: View {
-    @State private var viewModel = ContentViewModel()
+    @State private var realityKitViewModel = RealityKitContentViewModel()
+    @State private var sceneKitViewModel = SceneKitContentViewModel()
+    @State private var selectedRenderer: MacExampleRenderer = .realityKit
     @State private var selectedModel: MacExampleModel = .alicia
+    @State private var selectedExpression: MacExampleExpression = .neutral
     
     var body: some View {
         VStack {
-            Picker("Model", selection: $selectedModel) {
-                ForEach(MacExampleModel.allCases) { model in
-                    Text(model.displayName).tag(model)
+            HStack {
+                Picker("Renderer", selection: $selectedRenderer) {
+                    ForEach(MacExampleRenderer.allCases) { renderer in
+                        Text(renderer.displayName).tag(renderer)
+                    }
                 }
+                .pickerStyle(.segmented)
+
+                Picker("Model", selection: $selectedModel) {
+                    ForEach(MacExampleModel.allCases) { model in
+                        Text(model.displayName).tag(model)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Expression", selection: $selectedExpression) {
+                    ForEach(MacExampleExpression.allCases) { expression in
+                        Text(expression.displayName).tag(expression)
+                    }
+                }
+                .pickerStyle(.segmented)
             }
-            .pickerStyle(.segmented)
             .padding([.top, .horizontal])
 
-            RealityView { content in
-                content.add(viewModel.rootEntity)
-            }
-            .task(id: selectedModel) {
-                await viewModel.loadEntity(model: selectedModel)
-            }
-            .onReceive(viewModel.updateTimer) { _ in
-                viewModel.update()
-            }
-            
-            if let errorMessage = viewModel.errorMessage {
-                Text("Error: \(errorMessage)")
-                    .foregroundColor(.red)
-                    .padding()
+            switch selectedRenderer {
+            case .sceneKit:
+                SceneKitRendererView(viewModel: sceneKitViewModel,
+                                     selectedModel: selectedModel,
+                                     selectedExpression: selectedExpression)
+            case .realityKit:
+                RealityKitRendererView(viewModel: realityKitViewModel,
+                                       selectedModel: selectedModel,
+                                       selectedExpression: selectedExpression)
             }
         }
         .frame(minWidth: 800, minHeight: 600)
     }
 }
 
+private struct RealityKitRendererView: View {
+    let viewModel: RealityKitContentViewModel
+    let selectedModel: MacExampleModel
+    let selectedExpression: MacExampleExpression
+
+    var body: some View {
+        RealityView { content in
+            content.add(viewModel.rootEntity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task(id: selectedModel) {
+            await viewModel.loadEntity(model: selectedModel, expression: selectedExpression)
+        }
+        .onChange(of: selectedExpression) { _, expression in
+            viewModel.setExpression(expression)
+        }
+        .onReceive(viewModel.updateTimer) { _ in
+            viewModel.update()
+        }
+        .overlay(alignment: .bottomLeading) {
+            if let errorMessage = viewModel.errorMessage {
+                ErrorMessageView(message: errorMessage)
+            }
+        }
+    }
+}
+
+private struct SceneKitRendererView: View {
+    let viewModel: SceneKitContentViewModel
+    let selectedModel: MacExampleModel
+    let selectedExpression: MacExampleExpression
+
+    var body: some View {
+        SceneKitView(scene: viewModel.scene)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .task(id: selectedModel) {
+                await viewModel.loadScene(model: selectedModel, expression: selectedExpression)
+            }
+            .onChange(of: selectedExpression) { _, expression in
+                viewModel.setExpression(expression)
+            }
+            .onReceive(viewModel.updateTimer) { _ in
+                viewModel.update()
+            }
+            .overlay(alignment: .bottomLeading) {
+                if let errorMessage = viewModel.errorMessage {
+                    ErrorMessageView(message: errorMessage)
+                }
+            }
+    }
+}
+
+private struct ErrorMessageView: View {
+    let message: String
+
+    var body: some View {
+        Text("Error: \(message)")
+            .foregroundStyle(.red)
+            .padding()
+    }
+}
+
 @MainActor
 @Observable
-final class ContentViewModel {
+final class RealityKitContentViewModel {
     let rootEntity = Entity()
     private(set) var errorMessage: String?
     private var vrmEntity: VRMEntity?
     private var time: TimeInterval = 0
     private var lastUpdateTime: Date?
     private var currentModel: MacExampleModel = .alicia
+    private var currentExpression: MacExampleExpression = .neutral
     
     let updateTimer = Timer.publish(every: 1.0 / 60.0, on: .main, in: .common).autoconnect()
     
-    func loadEntity(model: MacExampleModel) async {
+    func loadEntity(model: MacExampleModel, expression: MacExampleExpression) async {
         do {
+            errorMessage = nil
             if let vrmEntity {
                 vrmEntity.entity.removeFromParent()
                 self.vrmEntity = nil
@@ -96,15 +176,23 @@ final class ContentViewModel {
             if let rightArm {
                 rightArm.transform.rotation = rightArm.transform.rotation * armRotation
             }
-            vrmEntity.setBlendShape(value: 1.0, for: .custom("><"))
+            vrmEntity.setBlendShape(value: 1.0, for: .preset(expression.preset))
             
             self.vrmEntity = vrmEntity
             self.currentModel = model
+            self.currentExpression = expression
             self.lastUpdateTime = Date()
         } catch {
             errorMessage = error.localizedDescription
             print("VRM Load Error: \(error)")
         }
+    }
+
+    func setExpression(_ expression: MacExampleExpression) {
+        guard expression != currentExpression else { return }
+        vrmEntity?.setBlendShape(value: 0.0, for: .preset(currentExpression.preset))
+        currentExpression = expression
+        vrmEntity?.setBlendShape(value: 1.0, for: .preset(expression.preset))
     }
     
     func update() {
@@ -133,6 +221,153 @@ final class ContentViewModel {
     }
 }
 
+private struct SceneKitView: NSViewRepresentable {
+    let scene: SCNScene?
+
+    func makeNSView(context: Context) -> SCNView {
+        let sceneView = SCNView()
+        sceneView.autoenablesDefaultLighting = true
+        sceneView.allowsCameraControl = true
+        sceneView.showsStatistics = true
+        sceneView.backgroundColor = .black
+        return sceneView
+    }
+
+    func updateNSView(_ sceneView: SCNView, context: Context) {
+        sceneView.scene = scene
+    }
+}
+
+@MainActor
+@Observable
+final class SceneKitContentViewModel {
+    private(set) var scene: VRMScene?
+    private(set) var errorMessage: String?
+    private var vrmNode: VRMNode?
+    private var time: TimeInterval = 0
+    private var lastUpdateTime: Date?
+    private var currentModel: MacExampleModel = .alicia
+    private var currentExpression: MacExampleExpression = .neutral
+
+    let updateTimer = Timer.publish(every: 1.0 / 60.0, on: .main, in: .common).autoconnect()
+
+    func loadScene(model: MacExampleModel, expression: MacExampleExpression) async {
+        do {
+            errorMessage = nil
+            scene = nil
+            vrmNode = nil
+            time = 0
+
+            let loader = try VRMSceneLoader(named: model.rawValue)
+            let scene = try loader.loadScene()
+            setUpCamera(in: scene)
+
+            let node = scene.vrmNode
+            node.eulerAngles = SCNVector3(0, CGFloat(model.sceneKitInitialRotation), 0)
+            applyPose(to: node)
+            node.setBlendShape(value: 1.0, for: .preset(expression.preset))
+
+            self.scene = scene
+            self.vrmNode = node
+            self.currentModel = model
+            self.currentExpression = expression
+            self.lastUpdateTime = Date()
+        } catch {
+            errorMessage = error.localizedDescription
+            print("VRM Load Error: \(error)")
+        }
+    }
+
+    func setExpression(_ expression: MacExampleExpression) {
+        guard expression != currentExpression else { return }
+        vrmNode?.setBlendShape(value: 0.0, for: .preset(currentExpression.preset))
+        currentExpression = expression
+        vrmNode?.setBlendShape(value: 1.0, for: .preset(expression.preset))
+    }
+
+    func update() {
+        guard let vrmNode else { return }
+
+        let now = Date()
+        let deltaTime = lastUpdateTime.map { now.timeIntervalSince($0) } ?? (1.0 / 60.0)
+        lastUpdateTime = now
+
+        time += deltaTime
+
+        let cycle = time.truncatingRemainder(dividingBy: 1.0)
+        let angle: Float
+        if cycle < 0.5 {
+            let progress = Float(cycle) / 0.5
+            angle = -0.5 * progress
+        } else {
+            let progress = Float(cycle - 0.5) / 0.5
+            angle = -0.5 + 0.5 * progress
+        }
+
+        vrmNode.eulerAngles = SCNVector3(0, CGFloat(currentModel.sceneKitInitialRotation + angle), 0)
+        vrmNode.update(at: time)
+    }
+
+    private func applyPose(to node: VRMNode) {
+        node.humanoid.node(for: .neck)?.eulerAngles = SCNVector3(0, 0, 20 * CGFloat.pi / 180)
+
+        let leftArm: SCNNode?
+        let rightArm: SCNNode?
+        switch node.vrm {
+        case .v1:
+            leftArm = node.humanoid.node(for: .leftShoulder)
+            rightArm = node.humanoid.node(for: .rightShoulder)
+        case .v0:
+            leftArm = node.humanoid.node(for: .leftUpperArm)
+            rightArm = node.humanoid.node(for: .rightUpperArm)
+        }
+        leftArm?.eulerAngles = SCNVector3(0, 0, 40 * CGFloat.pi / 180)
+        rightArm?.eulerAngles = SCNVector3(0, 0, 40 * CGFloat.pi / 180)
+    }
+
+    private func setUpCamera(in scene: SCNScene) {
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        cameraNode.position = SCNVector3(0, 0.8, -1.6)
+        cameraNode.rotation = SCNVector4(0, 1, 0, Float.pi)
+        scene.rootNode.addChildNode(cameraNode)
+    }
+}
+
+enum MacExampleRenderer: String, CaseIterable, Identifiable {
+    case sceneKit
+    case realityKit
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .sceneKit: return "SceneKit"
+        case .realityKit: return "RealityKit"
+        }
+    }
+}
+
+enum MacExampleExpression: String, CaseIterable, Identifiable {
+    case neutral, joy, angry, sorrow, fun
+
+    var id: String { rawValue }
+
+    var preset: BlendShapePreset {
+        switch self {
+        case .neutral: return .neutral
+        case .joy: return .joy
+        case .angry: return .angry
+        case .sorrow: return .sorrow
+        case .fun: return .fun
+        }
+    }
+
+    var displayName: String {
+        rawValue.capitalized
+    }
+}
+
 enum MacExampleModel: String, CaseIterable, Identifiable {
     case alicia = "AliciaSolid.vrm"
     case vrm1 = "VRM1_Constraint_Twist_Sample.vrm"
@@ -150,6 +385,13 @@ enum MacExampleModel: String, CaseIterable, Identifiable {
         switch self {
         case .alicia: return .pi
         case .vrm1: return 0
+        }
+    }
+
+    var sceneKitInitialRotation: Float {
+        switch self {
+        case .alicia: return 0
+        case .vrm1: return .pi
         }
     }
 }

--- a/Sources/VRMKit/VRM/Material.swift
+++ b/Sources/VRMKit/VRM/Material.swift
@@ -35,7 +35,7 @@ extension GLTF {
 
         public struct PbrMetallicRoughness: Codable {
             let _baseColorFactor: Color4?
-            public var baseColorFactor: Color4 { return _baseColorFactor ?? .init(r: 0, g: 0, b: 0, a: 0) }
+            public var baseColorFactor: Color4 { return _baseColorFactor ?? .init(r: 1, g: 1, b: 1, a: 1) }
             public let baseColorTexture: TextureInfo?
             let _metallicFactor: Float?
             public var metallicFactor: Float { return _metallicFactor ?? 1 }

--- a/Sources/VRMKit/VRMLoader.swift
+++ b/Sources/VRMKit/VRMLoader.swift
@@ -35,7 +35,11 @@ open class VRMLoader {
         guard let textureIndex = vrm0.meta.texture, textureIndex >= 0 else {
             throw VRMError.thumbnailNotFound
         }
-        let texture = try vrm0.gltf.jsonData.load(\.textures)[textureIndex]
+        let textures = try vrm0.gltf.jsonData.load(\.textures)
+        guard textures.indices.contains(textureIndex) else {
+            throw VRMError.thumbnailNotFound
+        }
+        let texture = textures[textureIndex]
         return try loadImage(from: vrm0.gltf, at: texture.source)
     }
 
@@ -47,7 +51,11 @@ open class VRMLoader {
     }
 
     private func loadImage(from gltf: BinaryGLTF, at index: Int, relativeTo rootDirectory: URL? = nil) throws -> VRMImage {
-        let gltfImage = try gltf.jsonData.load(\.images)[index]
+        let images = try gltf.jsonData.load(\.images)
+        guard images.indices.contains(index) else {
+            throw VRMError.thumbnailNotFound
+        }
+        let gltfImage = images[index]
         let imageData: Data
         if let uri = gltfImage.uri {
             imageData = try Data(gltfUrlString: uri, relativeTo: rootDirectory)

--- a/Sources/VRMKit/VRMLoader.swift
+++ b/Sources/VRMKit/VRMLoader.swift
@@ -23,17 +23,20 @@ open class VRMLoader {
     }
 
     open func loadThumbnail(from vrm: VRM) throws -> VRMImage {
-        guard let textureIndex = vrm.meta.texture, textureIndex >= 0 else {
-            throw VRMError.thumbnailNotFound
+        switch vrm {
+        case .v0(let vrm0):
+            return try loadThumbnail(from: vrm0)
+        case .v1(let vrm1):
+            return try loadThumbnail(from: vrm1)
         }
-        return try loadImage(from: vrm.gltf, at: textureIndex)
     }
 
     open func loadThumbnail(from vrm0: VRM0) throws -> VRMImage {
         guard let textureIndex = vrm0.meta.texture, textureIndex >= 0 else {
             throw VRMError.thumbnailNotFound
         }
-        return try loadImage(from: vrm0.gltf, at: textureIndex)
+        let texture = try vrm0.gltf.jsonData.load(\.textures)[textureIndex]
+        return try loadImage(from: vrm0.gltf, at: texture.source)
     }
 
     open func loadThumbnail(from vrm1: VRM1) throws -> VRMImage {

--- a/Sources/VRMKitRuntime/BlendShapeTypes.swift
+++ b/Sources/VRMKitRuntime/BlendShapeTypes.swift
@@ -10,7 +10,7 @@ public enum BlendShapeKey: Hashable {
     }
 }
 
-/// VRM 0.x Blend Shape Preset
+/// VRM expression preset.
 public enum BlendShapePreset: String {
     case unknown
     case neutral
@@ -30,8 +30,117 @@ public enum BlendShapePreset: String {
     case lookRight = "lookright"
     case blinkL = "blink_l"
     case blinkR = "blink_r"
+    case happy
+    case sad
+    case relaxed
+    case surprised
+    case aa
+    case ih
+    case ou
+    case ee
+    case oh
+    case blinkLeft
+    case blinkRight
 
     public init(name: String) {
-        self = BlendShapePreset(rawValue: name.lowercased()) ?? .unknown
+        switch name.replacingOccurrences(of: "_", with: "").lowercased() {
+        case "neutral":
+            self = .neutral
+        case "a":
+            self = .a
+        case "i":
+            self = .i
+        case "u":
+            self = .u
+        case "e":
+            self = .e
+        case "o":
+            self = .o
+        case "blink":
+            self = .blink
+        case "joy":
+            self = .joy
+        case "angry":
+            self = .angry
+        case "sorrow":
+            self = .sorrow
+        case "fun":
+            self = .fun
+        case "lookup":
+            self = .lookUp
+        case "lookdown":
+            self = .lookDown
+        case "lookleft":
+            self = .lookLeft
+        case "lookright":
+            self = .lookRight
+        case "blinkl":
+            self = .blinkL
+        case "blinkr":
+            self = .blinkR
+        case "happy":
+            self = .happy
+        case "sad":
+            self = .sad
+        case "relaxed":
+            self = .relaxed
+        case "surprised":
+            self = .surprised
+        case "aa":
+            self = .aa
+        case "ih":
+            self = .ih
+        case "ou":
+            self = .ou
+        case "ee":
+            self = .ee
+        case "oh":
+            self = .oh
+        case "blinkleft":
+            self = .blinkLeft
+        case "blinkright":
+            self = .blinkRight
+        default:
+            self = .unknown
+        }
+    }
+}
+
+package extension BlendShapePreset {
+    var aliases: [BlendShapePreset] {
+        switch self {
+        case .joy: return [.happy]
+        case .happy: return [.joy]
+        case .sorrow: return [.sad]
+        case .sad: return [.sorrow]
+        case .fun: return [.relaxed]
+        case .relaxed: return [.fun]
+        case .a: return [.aa]
+        case .aa: return [.a]
+        case .i: return [.ih]
+        case .ih: return [.i]
+        case .u: return [.ou]
+        case .ou: return [.u]
+        case .e: return [.ee]
+        case .ee: return [.e]
+        case .o: return [.oh]
+        case .oh: return [.o]
+        case .blinkL: return [.blinkLeft]
+        case .blinkLeft: return [.blinkL]
+        case .blinkR: return [.blinkRight]
+        case .blinkRight: return [.blinkR]
+        default: return []
+        }
+    }
+}
+
+package extension BlendShapeKey {
+    var aliases: [BlendShapeKey] {
+        switch self {
+        case .preset(let preset):
+            return preset.aliases.map(BlendShapeKey.preset)
+        case .custom:
+            return []
+        }
     }
 }

--- a/Sources/VRMKitRuntime/FirstPersonRenderMode.swift
+++ b/Sources/VRMKitRuntime/FirstPersonRenderMode.swift
@@ -1,0 +1,4 @@
+public enum FirstPersonRenderMode {
+    case firstPerson
+    case thirdPerson
+}

--- a/Sources/VRMKitRuntime/Humanoid.swift
+++ b/Sources/VRMKitRuntime/Humanoid.swift
@@ -14,6 +14,73 @@ public final class Humanoid<Node> {
         }
     }
 
+    package func setUp(humanoid: VRM1.Humanoid, nodes: [Node?]) {
+        let humanBones = humanoid.humanBones
+        let mappings: [(Bones, VRM1.Humanoid.HumanBones.HumanBone?)] = [
+            (.hips, humanBones.hips),
+            (.spine, humanBones.spine),
+            (.chest, humanBones.chest),
+            (.upperChest, humanBones.upperChest),
+            (.neck, humanBones.neck),
+            (.head, humanBones.head),
+            (.leftEye, humanBones.leftEye),
+            (.rightEye, humanBones.rightEye),
+            (.jaw, humanBones.jaw),
+            (.leftUpperLeg, humanBones.leftUpperLeg),
+            (.leftLowerLeg, humanBones.leftLowerLeg),
+            (.leftFoot, humanBones.leftFoot),
+            (.leftToes, humanBones.leftToes),
+            (.rightUpperLeg, humanBones.rightUpperLeg),
+            (.rightLowerLeg, humanBones.rightLowerLeg),
+            (.rightFoot, humanBones.rightFoot),
+            (.rightToes, humanBones.rightToes),
+            (.leftShoulder, humanBones.leftShoulder),
+            (.leftUpperArm, humanBones.leftUpperArm),
+            (.leftLowerArm, humanBones.leftLowerArm),
+            (.leftHand, humanBones.leftHand),
+            (.rightShoulder, humanBones.rightShoulder),
+            (.rightUpperArm, humanBones.rightUpperArm),
+            (.rightLowerArm, humanBones.rightLowerArm),
+            (.rightHand, humanBones.rightHand),
+            (.leftThumbMetacarpal, humanBones.leftThumbMetacarpal),
+            (.leftThumbProximal, humanBones.leftThumbProximal),
+            (.leftThumbDistal, humanBones.leftThumbDistal),
+            (.leftIndexProximal, humanBones.leftIndexProximal),
+            (.leftIndexIntermediate, humanBones.leftIndexIntermediate),
+            (.leftIndexDistal, humanBones.leftIndexDistal),
+            (.leftMiddleProximal, humanBones.leftMiddleProximal),
+            (.leftMiddleIntermediate, humanBones.leftMiddleIntermediate),
+            (.leftMiddleDistal, humanBones.leftMiddleDistal),
+            (.leftRingProximal, humanBones.leftRingProximal),
+            (.leftRingIntermediate, humanBones.leftRingIntermediate),
+            (.leftRingDistal, humanBones.leftRingDistal),
+            (.leftLittleProximal, humanBones.leftLittleProximal),
+            (.leftLittleIntermediate, humanBones.leftLittleIntermediate),
+            (.leftLittleDistal, humanBones.leftLittleDistal),
+            (.rightThumbMetacarpal, humanBones.rightThumbMetacarpal),
+            (.rightThumbProximal, humanBones.rightThumbProximal),
+            (.rightThumbDistal, humanBones.rightThumbDistal),
+            (.rightIndexProximal, humanBones.rightIndexProximal),
+            (.rightIndexIntermediate, humanBones.rightIndexIntermediate),
+            (.rightIndexDistal, humanBones.rightIndexDistal),
+            (.rightMiddleProximal, humanBones.rightMiddleProximal),
+            (.rightMiddleIntermediate, humanBones.rightMiddleIntermediate),
+            (.rightMiddleDistal, humanBones.rightMiddleDistal),
+            (.rightRingProximal, humanBones.rightRingProximal),
+            (.rightRingIntermediate, humanBones.rightRingIntermediate),
+            (.rightRingDistal, humanBones.rightRingDistal),
+            (.rightLittleProximal, humanBones.rightLittleProximal),
+            (.rightLittleIntermediate, humanBones.rightLittleIntermediate),
+            (.rightLittleDistal, humanBones.rightLittleDistal)
+        ]
+        bones = mappings.reduce(into: [:]) { result, mapping in
+            guard let humanBone = mapping.1,
+                  nodes.indices.contains(humanBone.node),
+                  let node = nodes[humanBone.node] else { return }
+            result[mapping.0] = node
+        }
+    }
+
     public func node(for bone: Bones) -> Node? {
         return bones[bone]
     }
@@ -27,6 +94,7 @@ public final class Humanoid<Node> {
         case leftFoot
         case rightFoot
         case spine
+        case chest
         case neck
         case head
         case leftShoulder
@@ -43,6 +111,7 @@ public final class Humanoid<Node> {
         case rightEye
         case jaw
         case leftThumbProximal
+        case leftThumbMetacarpal
         case leftThumbIntermediate
         case leftThumbDistal
         case leftIndexProximal
@@ -58,6 +127,7 @@ public final class Humanoid<Node> {
         case leftLittleIntermediate
         case leftLittleDistal
         case rightThumbProximal
+        case rightThumbMetacarpal
         case rightThumbIntermediate
         case rightThumbDistal
         case rightIndexProximal

--- a/Sources/VRMKitRuntime/VRM1Expressions+Runtime.swift
+++ b/Sources/VRMKitRuntime/VRM1Expressions+Runtime.swift
@@ -1,0 +1,40 @@
+import VRMKit
+
+package extension VRM1.Expressions {
+    var runtimeClips: [(name: String, preset: BlendShapePreset, expression: VRM1.Expressions.Expression)] {
+        var clips: [(String, BlendShapePreset, VRM1.Expressions.Expression)] = [
+            ("Happy", .happy, preset.happy),
+            ("Angry", .angry, preset.angry),
+            ("Sad", .sad, preset.sad),
+            ("Relaxed", .relaxed, preset.relaxed),
+            ("Surprised", .surprised, preset.surprised),
+            ("Aa", .aa, preset.aa),
+            ("Ih", .ih, preset.ih),
+            ("Ou", .ou, preset.ou),
+            ("Ee", .ee, preset.ee),
+            ("Oh", .oh, preset.oh),
+            ("Blink", .blink, preset.blink),
+            ("BlinkLeft", .blinkLeft, preset.blinkLeft),
+            ("BlinkRight", .blinkRight, preset.blinkRight),
+            ("LookUp", .lookUp, preset.lookUp),
+            ("LookDown", .lookDown, preset.lookDown),
+            ("LookLeft", .lookLeft, preset.lookLeft),
+            ("LookRight", .lookRight, preset.lookRight),
+            ("Neutral", .neutral, preset.neutral)
+        ]
+
+        guard let customMap = custom?.value as? [String: Any] else {
+            return clips
+        }
+
+        let decoder = DictionaryDecoder()
+        for name in customMap.keys.sorted() {
+            guard let raw = customMap[name] as? [String: Any],
+                  let expression = try? decoder.decode(VRM1.Expressions.Expression.self, from: raw) else {
+                continue
+            }
+            clips.append((name, .unknown, expression))
+        }
+        return clips
+    }
+}

--- a/Sources/VRMKitRuntime/VRM1NodeConstraintRuntime.swift
+++ b/Sources/VRMKitRuntime/VRM1NodeConstraintRuntime.swift
@@ -1,0 +1,204 @@
+import simd
+import VRMKit
+
+package enum VRMNodeConstraintDescriptor {
+    case roll(source: Int, axis: RollAxis, weight: Float)
+    case aim(source: Int, axis: AimAxis, weight: Float)
+    case rotation(source: Int, weight: Float)
+
+    package enum RollAxis {
+        case x
+        case y
+        case z
+    }
+
+    package enum AimAxis {
+        case positiveX
+        case negativeX
+        case positiveY
+        case negativeY
+        case positiveZ
+        case negativeZ
+    }
+
+    package init?(_ constraint: GLTF.Node.NodeExtensions.NodeConstraint.Constraint) {
+        if let roll = constraint.roll {
+            self = .roll(source: roll.source,
+                         axis: RollAxis(roll.rollAxis),
+                         weight: Float(roll.weight ?? 1.0))
+        } else if let aim = constraint.aim {
+            self = .aim(source: aim.source,
+                        axis: AimAxis(aim.aimAxis),
+                        weight: Float(aim.weight ?? 1.0))
+        } else if let rotation = constraint.rotation {
+            self = .rotation(source: rotation.source,
+                             weight: Float(rotation.weight ?? 1.0))
+        } else {
+            return nil
+        }
+    }
+
+    package var source: Int {
+        switch self {
+        case .roll(let source, _, _),
+             .aim(let source, _, _),
+             .rotation(let source, _):
+            return source
+        }
+    }
+}
+
+package enum VRMNodeConstraintRuntime {
+    package static func evaluate(_ descriptor: VRMNodeConstraintDescriptor,
+                                 sourceRestRotation: simd_quatf,
+                                 sourceLocalRotation: simd_quatf,
+                                 sourceWorldPosition: SIMD3<Float>,
+                                 destinationRestRotation: simd_quatf,
+                                 destinationParentWorldRotation: simd_quatf,
+                                 destinationWorldPosition: SIMD3<Float>) -> simd_quatf {
+        switch descriptor {
+        case .roll(_, let axis, let weight):
+            return evaluateRoll(axis: axis.vector,
+                                weight: weight,
+                                sourceRestRotation: sourceRestRotation,
+                                sourceLocalRotation: sourceLocalRotation,
+                                destinationRestRotation: destinationRestRotation)
+        case .aim(_, let axis, let weight):
+            return evaluateAim(axis: axis.vector,
+                               weight: weight,
+                               sourceWorldPosition: sourceWorldPosition,
+                               destinationRestRotation: destinationRestRotation,
+                               destinationParentWorldRotation: destinationParentWorldRotation,
+                               destinationWorldPosition: destinationWorldPosition)
+        case .rotation(_, let weight):
+            return evaluateRotation(weight: weight,
+                                    sourceRestRotation: sourceRestRotation,
+                                    sourceLocalRotation: sourceLocalRotation,
+                                    destinationRestRotation: destinationRestRotation)
+        }
+    }
+
+    private static func evaluateRoll(axis: SIMD3<Float>,
+                                     weight: Float,
+                                     sourceRestRotation: simd_quatf,
+                                     sourceLocalRotation: simd_quatf,
+                                     destinationRestRotation: simd_quatf) -> simd_quatf {
+        let deltaSource = simd_inverse(sourceRestRotation) * sourceLocalRotation
+        let deltaSourceInParent = sourceRestRotation * deltaSource * simd_inverse(sourceRestRotation)
+        let deltaSourceInDestination = simd_inverse(destinationRestRotation) * deltaSourceInParent * destinationRestRotation
+
+        let toVector = deltaSourceInDestination * axis
+        let fromToRotation = Self.fromToRotation(from: axis, to: toVector)
+        let constrained = destinationRestRotation * simd_inverse(fromToRotation) * deltaSourceInDestination
+        return slerpRest(destinationRestRotation, constrained, weight: weight)
+    }
+
+    private static func evaluateAim(axis: SIMD3<Float>,
+                                    weight: Float,
+                                    sourceWorldPosition: SIMD3<Float>,
+                                    destinationRestRotation: simd_quatf,
+                                    destinationParentWorldRotation: simd_quatf,
+                                    destinationWorldPosition: SIMD3<Float>) -> simd_quatf {
+        let fromVector = destinationParentWorldRotation * destinationRestRotation * axis
+        let toVector = sourceWorldPosition - destinationWorldPosition
+        let fromToRotation = Self.fromToRotation(from: fromVector, to: toVector)
+        let constrained = simd_inverse(destinationParentWorldRotation) *
+            fromToRotation *
+            destinationParentWorldRotation *
+            destinationRestRotation
+        return slerpRest(destinationRestRotation, constrained, weight: weight)
+    }
+
+    private static func evaluateRotation(weight: Float,
+                                         sourceRestRotation: simd_quatf,
+                                         sourceLocalRotation: simd_quatf,
+                                         destinationRestRotation: simd_quatf) -> simd_quatf {
+        let deltaSource = simd_inverse(sourceRestRotation) * sourceLocalRotation
+        return slerpRest(destinationRestRotation,
+                         destinationRestRotation * deltaSource,
+                         weight: weight)
+    }
+
+    private static func slerpRest(_ rest: simd_quatf,
+                                  _ constrained: simd_quatf,
+                                  weight: Float) -> simd_quatf {
+        simd_slerp(normalized(rest), normalized(constrained), clamped(weight))
+    }
+
+    private static func fromToRotation(from rawFrom: SIMD3<Float>,
+                                       to rawTo: SIMD3<Float>) -> simd_quatf {
+        guard simd_length_squared(rawFrom) > Float.ulpOfOne,
+              simd_length_squared(rawTo) > Float.ulpOfOne else {
+            return quat_identity_float
+        }
+
+        let from = simd_normalize(rawFrom)
+        let to = simd_normalize(rawTo)
+        let dotValue = clamped(simd_dot(from, to), min: -1.0, max: 1.0)
+        if dotValue > 1.0 - 0.000001 {
+            return quat_identity_float
+        }
+        if dotValue < -1.0 + 0.000001 {
+            let fallback = abs(from.x) < 0.9 ? SIMD3<Float>(1, 0, 0) : SIMD3<Float>(0, 1, 0)
+            let axis = simd_normalize(simd_cross(from, fallback))
+            return simd_quatf(angle: .pi, axis: axis)
+        }
+
+        let axis = simd_normalize(simd_cross(from, to))
+        return simd_quatf(angle: acos(dotValue), axis: axis)
+    }
+
+    private static func normalized(_ quaternion: simd_quatf) -> simd_quatf {
+        let lengthSquared = simd_dot(quaternion.vector, quaternion.vector)
+        guard lengthSquared > Float.ulpOfOne else { return quat_identity_float }
+        return simd_quatf(vector: quaternion.vector / sqrt(lengthSquared))
+    }
+
+    private static func clamped(_ value: Float,
+                                min minimum: Float = 0.0,
+                                max maximum: Float = 1.0) -> Float {
+        Swift.min(Swift.max(value, minimum), maximum)
+    }
+}
+
+private extension VRMNodeConstraintDescriptor.RollAxis {
+    init(_ axis: GLTF.Node.NodeExtensions.NodeConstraint.Constraint.RollConstraint.RollAxis) {
+        switch axis {
+        case .x: self = .x
+        case .y: self = .y
+        case .z: self = .z
+        }
+    }
+
+    var vector: SIMD3<Float> {
+        switch self {
+        case .x: return SIMD3<Float>(1, 0, 0)
+        case .y: return SIMD3<Float>(0, 1, 0)
+        case .z: return SIMD3<Float>(0, 0, 1)
+        }
+    }
+}
+
+private extension VRMNodeConstraintDescriptor.AimAxis {
+    init(_ axis: GLTF.Node.NodeExtensions.NodeConstraint.Constraint.AimConstraint.AimAxis) {
+        switch axis {
+        case .positiveX: self = .positiveX
+        case .negativeX: self = .negativeX
+        case .positiveY: self = .positiveY
+        case .negativeY: self = .negativeY
+        case .positiveZ: self = .positiveZ
+        case .negativeZ: self = .negativeZ
+        }
+    }
+
+    var vector: SIMD3<Float> {
+        switch self {
+        case .positiveX: return SIMD3<Float>(1, 0, 0)
+        case .negativeX: return SIMD3<Float>(-1, 0, 0)
+        case .positiveY: return SIMD3<Float>(0, 1, 0)
+        case .negativeY: return SIMD3<Float>(0, -1, 0)
+        case .positiveZ: return SIMD3<Float>(0, 0, 1)
+        case .negativeZ: return SIMD3<Float>(0, 0, -1)
+        }
+    }
+}

--- a/Sources/VRMRealityKit/CustomType/VRMEntity.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntity.swift
@@ -576,7 +576,13 @@ private struct NodeConstraintBinding {
     }
 
     static func ordered(_ bindings: [NodeConstraintBinding]) throws -> [NodeConstraintBinding] {
-        let byTargetIndex = Dictionary(uniqueKeysWithValues: bindings.map { ($0.targetIndex, $0) })
+        var byTargetIndex: [Int: NodeConstraintBinding] = [:]
+        for binding in bindings {
+            if byTargetIndex[binding.targetIndex] != nil {
+                throw VRMError._dataInconsistent("Multiple constraints targeting the same node \(binding.targetIndex)")
+            }
+            byTargetIndex[binding.targetIndex] = binding
+        }
         var states: [Int: VisitState] = [:]
         var result: [NodeConstraintBinding] = []
 

--- a/Sources/VRMRealityKit/CustomType/VRMEntity.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntity.swift
@@ -2,6 +2,7 @@
 import CoreGraphics
 import Foundation
 import RealityKit
+import simd
 import VRMKit
 import VRMKitRuntime
 
@@ -14,6 +15,11 @@ struct BlendShapeNormalTangentComponent: Component {
 }
 
 @available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+struct VRMMaterialIndexComponent: Component {
+    let materialIndex: Int
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 @MainActor
 public final class VRMEntity {
     public let vrm: VRM
@@ -23,8 +29,12 @@ public final class VRMEntity {
     private let enableNormalTangentBlendShape = false
 
     var blendShapeClips: [BlendShapeKey: BlendShapeClip] = [:]
+    private var materialColorClips: [BlendShapeKey: [MaterialColorBinding]] = [:]
+    private var firstPersonAnnotations: [FirstPersonAnnotation] = []
     private var skinBindings: [SkinBinding] = []
+    private var modelEntitiesByMaterialIndex: [Int: [ModelEntity]] = [:]
     private var springBones: [VRMEntitySpringBone] = []
+    private var nodeConstraints: [NodeConstraintBinding] = []
 
     struct SkinBinding {
         let modelEntity: ModelEntity
@@ -38,49 +48,177 @@ public final class VRMEntity {
     }
 
     func setUpHumanoid(nodes: [Entity?]) {
-        humanoid.setUp(humanoid: vrm.humanoid, nodes: nodes)
+        switch vrm {
+        case .v0:
+            humanoid.setUp(humanoid: vrm.humanoid, nodes: nodes)
+        case .v1(let vrm1):
+            humanoid.setUp(humanoid: vrm1.humanoid, nodes: nodes)
+        }
     }
 
-    func setUpBlendShapes(meshes: [Entity?]) {
-        blendShapeClips = vrm.blendShapeMaster.blendShapeGroups
-            .map { group in
-                let blendShapeBinding: [BlendShapeBinding] = group.binds?
-                    .compactMap {
-                        guard let mesh = meshes[$0.mesh] else {
+    func setUpBlendShapes(nodes: [Entity?], meshes: [Entity?], loader: VRMEntityLoader) throws {
+        blendShapeClips = [:]
+        materialColorClips = [:]
+
+        switch vrm {
+        case .v0:
+            blendShapeClips = vrm.blendShapeMaster.blendShapeGroups
+                .map { group in
+                    let blendShapeBinding: [BlendShapeBinding] = group.binds?
+                        .compactMap {
+                            guard meshes.indices.contains($0.mesh),
+                                  let mesh = meshes[$0.mesh] else {
+                                return nil
+                            }
+                            return BlendShapeBinding(mesh: mesh, index: $0.index, weight: $0.weight)
+                        } ?? []
+                    return BlendShapeClip(name: group.name,
+                                          preset: BlendShapePreset(name: group.presetName),
+                                          values: blendShapeBinding,
+                                          isBinary: group.isBinary)
+                }
+                .reduce(into: [:]) { result, clip in
+                    result[clip.key] = clip
+                }
+        case .v1(let vrm1):
+            guard let expressions = vrm1.expressions else { return }
+            for expressionClip in expressions.runtimeClips {
+                let morphBindings: [BlendShapeBinding] = expressionClip.expression.morphTargetBinds?
+                    .compactMap { bind in
+                        guard nodes.indices.contains(bind.node),
+                              let node = nodes[bind.node] else {
                             return nil
                         }
-                        return BlendShapeBinding(mesh: mesh, index: $0.index, weight: $0.weight)
+                        return BlendShapeBinding(mesh: node, index: bind.index, weight: bind.weight * 100.0)
                     } ?? []
-                return BlendShapeClip(name: group.name,
-                                      preset: BlendShapePreset(name: group.presetName),
-                                      values: blendShapeBinding,
-                                      isBinary: group.isBinary)
+                let clip = BlendShapeClip(name: expressionClip.name,
+                                          preset: expressionClip.preset,
+                                          values: morphBindings,
+                                          isBinary: expressionClip.expression.isBinary ?? false)
+                blendShapeClips[clip.key] = clip
+
+                let colorBindings: [MaterialColorBinding] = try expressionClip.expression.materialColorBinds?
+                    .compactMap { bind in
+                        guard bind.targetValue.count >= 3 else { return nil }
+                        let material = try loader.material(withMaterialIndex: bind.material)
+                        return MaterialColorBinding(materialIndex: bind.material,
+                                                    type: bind.type,
+                                                    targetValue: SIMD4<Float>(bind.targetValue, defaultAlpha: 1.0),
+                                                    baseValue: material.currentColor(for: bind.type))
+                    } ?? []
+                if !colorBindings.isEmpty {
+                    materialColorClips[clip.key] = colorBindings
+                }
             }
-            .reduce(into: [:]) { result, clip in
-                result[clip.key] = clip
+        }
+    }
+
+    func setUpFirstPerson(nodes: [Entity?], meshes: [Entity?]) {
+        switch vrm {
+        case .v0:
+            firstPersonAnnotations = vrm.firstPerson.meshAnnotations.compactMap { annotation in
+                guard meshes.indices.contains(annotation.mesh),
+                      let mesh = meshes[annotation.mesh],
+                      let type = FirstPersonAnnotationType(vrm0Flag: annotation.firstPersonFlag) else {
+                    return nil
+                }
+                return FirstPersonAnnotation(entity: mesh, type: type)
             }
+        case .v1(let vrm1):
+            firstPersonAnnotations = vrm1.firstPerson?.meshAnnotations.compactMap { annotation in
+                guard nodes.indices.contains(annotation.node),
+                      let node = nodes[annotation.node] else {
+                    return nil
+                }
+                return FirstPersonAnnotation(entity: node, type: FirstPersonAnnotationType(vrm1Type: annotation.type))
+            } ?? []
+        }
+        setFirstPersonRenderMode(.thirdPerson)
+    }
+
+    func setUpNodeConstraints(gltfNodes: [GLTF.Node], loader: VRMEntityLoader) throws {
+        guard case .v1 = vrm else {
+            nodeConstraints = []
+            return
+        }
+
+        var bindings: [NodeConstraintBinding] = []
+        for (targetIndex, gltfNode) in gltfNodes.enumerated() {
+            guard let constraint = gltfNode.extensions?.nodeConstraint?.constraint,
+                  let descriptor = VRMNodeConstraintDescriptor(constraint) else {
+                continue
+            }
+            let sourceIndex = descriptor.source
+            guard sourceIndex != targetIndex else {
+                throw VRMError._dataInconsistent("VRMC_node_constraint source must not be destination: \(targetIndex)")
+            }
+            guard gltfNodes.indices.contains(sourceIndex) else {
+                throw VRMError._dataInconsistent("VRMC_node_constraint source index is out of range: \(sourceIndex)")
+            }
+
+            let target = try loader.node(withNodeIndex: targetIndex)
+            let source = try loader.node(withNodeIndex: sourceIndex)
+            bindings.append(NodeConstraintBinding(targetIndex: targetIndex,
+                                                  sourceIndex: sourceIndex,
+                                                  descriptor: descriptor,
+                                                  target: target,
+                                                  source: source))
+        }
+        nodeConstraints = try NodeConstraintBinding.ordered(bindings)
     }
 
     func setUpSpringBones(loader: VRMEntityLoader) throws {
         var springBones: [VRMEntitySpringBone] = []
-        let secondaryAnimation = vrm.secondaryAnimation
-        for boneGroup in secondaryAnimation.boneGroups {
-            guard !boneGroup.bones.isEmpty else { continue }
-            let rootBones: [Entity] = try boneGroup.bones.compactMap { try loader.node(withNodeIndex: $0) }
-            let centerNode = try? loader.node(withNodeIndex: boneGroup.center)
-            let colliderGroups = try secondaryAnimation.colliderGroups.map {
+        switch vrm {
+        case .v0:
+            let secondaryAnimation = vrm.secondaryAnimation
+            let allColliderGroups = try secondaryAnimation.colliderGroups.map {
                 try VRMEntitySpringBoneColliderGroup(colliderGroup: $0, loader: loader)
             }
-            let springBone = VRMEntitySpringBone(center: centerNode,
-                                                     rootBones: rootBones,
-                                                     comment: boneGroup.comment,
-                                                     stiffnessForce: Float(boneGroup.stiffiness),
-                                                     gravityPower: Float(boneGroup.gravityPower),
-                                                     gravityDir: SIMD3<Float>(Float(boneGroup.gravityDir.x), Float(boneGroup.gravityDir.y), Float(boneGroup.gravityDir.z)),
-                                                     dragForce: Float(boneGroup.dragForce),
-                                                     hitRadius: Float(boneGroup.hitRadius),
+            for boneGroup in secondaryAnimation.boneGroups {
+                guard !boneGroup.bones.isEmpty else { continue }
+                let rootBones: [Entity] = try boneGroup.bones.compactMap { try loader.node(withNodeIndex: $0) }
+                let centerNode = try? loader.node(withNodeIndex: boneGroup.center)
+                let colliderGroups = boneGroup.colliderGroups.compactMap { index in
+                    allColliderGroups.indices.contains(index) ? allColliderGroups[index] : nil
+                }
+                let springBone = VRMEntitySpringBone(center: centerNode,
+                                                         rootBones: rootBones,
+                                                         comment: boneGroup.comment,
+                                                         stiffnessForce: Float(boneGroup.stiffiness),
+                                                         gravityPower: Float(boneGroup.gravityPower),
+                                                         gravityDir: SIMD3<Float>(Float(boneGroup.gravityDir.x), Float(boneGroup.gravityDir.y), Float(boneGroup.gravityDir.z)),
+                                                         dragForce: Float(boneGroup.dragForce),
+                                                         hitRadius: Float(boneGroup.hitRadius),
+                                                         colliderGroups: colliderGroups)
+                springBones.append(springBone)
+            }
+        case .v1(let vrm1):
+            guard let springBone = vrm1.springBone else { break }
+            for spring in springBone.springs ?? [] {
+                let jointEntities = try spring.joints.compactMap { try loader.node(withNodeIndex: $0.node) }
+                guard !jointEntities.isEmpty else { continue }
+                let centerEntity = try spring.center.map { try loader.node(withNodeIndex: $0) }
+                let colliderGroups = try spring.colliderGroups?.compactMap { groupIndex -> VRMEntitySpringBoneColliderGroup? in
+                    guard let groups = springBone.colliderGroups,
+                          groups.indices.contains(groupIndex) else {
+                        return nil
+                    }
+                    return try VRMEntitySpringBoneColliderGroup(colliderGroup: groups[groupIndex],
+                                                                springBone: springBone,
+                                                                loader: loader)
+                } ?? []
+                let settings = Dictionary(uniqueKeysWithValues: zip(jointEntities, spring.joints).map { entity, joint in
+                    (ObjectIdentifier(entity), VRMEntitySpringBone.JointSetting(joint: joint))
+                })
+                let springBone = VRMEntitySpringBone(center: centerEntity,
+                                                     rootBones: [jointEntities[0]],
+                                                     comment: spring.name,
+                                                     jointChain: jointEntities,
+                                                     jointSettings: settings,
                                                      colliderGroups: colliderGroups)
-            springBones.append(springBone)
+                springBones.append(springBone)
+            }
         }
         self.springBones = springBones
     }
@@ -95,7 +233,12 @@ public final class VRMEntity {
         initializeSkinPose(for: binding)
     }
 
+    func registerMaterialBinding(modelEntity: ModelEntity, materialIndex: Int) {
+        modelEntitiesByMaterialIndex[materialIndex, default: []].append(modelEntity)
+    }
+
     public func update(at time: TimeInterval) {
+        nodeConstraints.forEach { $0.apply() }
         updateSkinning()
         springBones.forEach { $0.update(deltaTime: time) }
     }
@@ -164,11 +307,14 @@ public final class VRMEntity {
     }
 
     public func setBlendShape(value: CGFloat, for key: BlendShapeKey) {
-        guard let clip = blendShapeClips[key] else { return }
+        guard let clip = blendShapeClip(for: key) else { return }
         let normalized = max(0.0, min(1.0, clip.isBinary ? round(value) : value))
         for binding in clip.values {
             let weight = Float(binding.weight / 100.0) * Float(normalized)
             applyBlendShapeWeight(weight, targetIndex: binding.index, on: binding.mesh)
+        }
+        for binding in materialColorClip(for: key) {
+            binding.apply(value: Float(normalized), on: self)
         }
         if enableNormalTangentBlendShape {
             var meshesToUpdate: [Entity] = []
@@ -186,9 +332,39 @@ public final class VRMEntity {
     }
 
     public func blendShape(for key: BlendShapeKey) -> CGFloat {
-        guard let clip = blendShapeClips[key],
+        guard let clip = blendShapeClip(for: key),
               let binding = clip.values.first else { return 0 }
         return CGFloat(readBlendShapeWeight(targetIndex: binding.index, on: binding.mesh))
+    }
+
+    public func setFirstPersonRenderMode(_ mode: FirstPersonRenderMode) {
+        for annotation in firstPersonAnnotations {
+            annotation.entity.isEnabled = !annotation.type.isHidden(in: mode)
+        }
+    }
+
+    fileprivate func applyMaterialColor(_ color: SIMD4<Float>,
+                                        type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType,
+                                        materialIndex: Int) {
+        guard let models = modelEntitiesByMaterialIndex[materialIndex] else { return }
+        let vrmColor = VRMColor(simd: color)
+        for modelEntity in models {
+            guard var component = modelEntity.components[ModelComponent.self] else { continue }
+            component.materials = component.materials.map { material in
+                material.settingColor(vrmColor, for: type)
+            }
+            modelEntity.components.set(component)
+        }
+    }
+
+    private func blendShapeClip(for key: BlendShapeKey) -> BlendShapeClip? {
+        if let clip = blendShapeClips[key] { return clip }
+        return key.aliases.lazy.compactMap { self.blendShapeClips[$0] }.first
+    }
+
+    private func materialColorClip(for key: BlendShapeKey) -> [MaterialColorBinding] {
+        if let clip = materialColorClips[key] { return clip }
+        return key.aliases.lazy.compactMap { self.materialColorClips[$0] }.first ?? []
     }
 
     private func modelEntities(in root: Entity) -> [ModelEntity] {
@@ -358,6 +534,221 @@ public final class VRMEntity {
         guard let model = modelEntity.components[ModelComponent.self] else { return }
         let mapping = BlendShapeWeightsMapping(meshResource: model.mesh)
         modelEntity.components.set(BlendShapeWeightsComponent(weightsMapping: mapping))
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+private struct NodeConstraintBinding {
+    let targetIndex: Int
+    let sourceIndex: Int
+    let descriptor: VRMNodeConstraintDescriptor
+    let target: Entity
+    let source: Entity
+    let targetRestRotation: simd_quatf
+    let sourceRestRotation: simd_quatf
+
+    @MainActor
+    init(targetIndex: Int,
+         sourceIndex: Int,
+         descriptor: VRMNodeConstraintDescriptor,
+         target: Entity,
+         source: Entity) {
+        self.targetIndex = targetIndex
+        self.sourceIndex = sourceIndex
+        self.descriptor = descriptor
+        self.target = target
+        self.source = source
+        self.targetRestRotation = target.utx.localRotation
+        self.sourceRestRotation = source.utx.localRotation
+    }
+
+    @MainActor
+    func apply() {
+        target.utx.localRotation = VRMNodeConstraintRuntime.evaluate(
+            descriptor,
+            sourceRestRotation: sourceRestRotation,
+            sourceLocalRotation: source.utx.localRotation,
+            sourceWorldPosition: source.utx.position,
+            destinationRestRotation: targetRestRotation,
+            destinationParentWorldRotation: target.parent?.utx.rotation ?? quat_identity_float,
+            destinationWorldPosition: target.utx.position
+        )
+    }
+
+    static func ordered(_ bindings: [NodeConstraintBinding]) throws -> [NodeConstraintBinding] {
+        let byTargetIndex = Dictionary(uniqueKeysWithValues: bindings.map { ($0.targetIndex, $0) })
+        var states: [Int: VisitState] = [:]
+        var result: [NodeConstraintBinding] = []
+
+        func visit(_ binding: NodeConstraintBinding) throws {
+            switch states[binding.targetIndex] {
+            case .done:
+                return
+            case .visiting:
+                throw VRMError._dataInconsistent("VRMC_node_constraint circular dependency detected at node \(binding.targetIndex)")
+            case .none:
+                break
+            }
+
+            states[binding.targetIndex] = .visiting
+            if let dependency = byTargetIndex[binding.sourceIndex] {
+                try visit(dependency)
+            }
+            states[binding.targetIndex] = .done
+            result.append(binding)
+        }
+
+        for binding in bindings {
+            try visit(binding)
+        }
+        return result
+    }
+
+    private enum VisitState {
+        case visiting
+        case done
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+private struct MaterialColorBinding {
+    let materialIndex: Int
+    let type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType
+    let targetValue: SIMD4<Float>
+    let baseValue: SIMD4<Float>
+
+    @MainActor
+    func apply(value: Float, on entity: VRMEntity) {
+        entity.applyMaterialColor(baseValue + (targetValue - baseValue) * value,
+                                  type: type,
+                                  materialIndex: materialIndex)
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+private struct FirstPersonAnnotation {
+    let entity: Entity
+    let type: FirstPersonAnnotationType
+}
+
+private enum FirstPersonAnnotationType {
+    case auto
+    case both
+    case thirdPersonOnly
+    case firstPersonOnly
+
+    init(vrm1Type: VRM1.FirstPerson.FirstPersonType) {
+        switch vrm1Type {
+        case .auto: self = .auto
+        case .both: self = .both
+        case .thirdPersonOnly: self = .thirdPersonOnly
+        case .firstPersonOnly: self = .firstPersonOnly
+        }
+    }
+
+    init?(vrm0Flag: String) {
+        switch vrm0Flag.replacingOccurrences(of: "_", with: "").lowercased() {
+        case "auto":
+            self = .auto
+        case "both":
+            self = .both
+        case "thirdpersononly":
+            self = .thirdPersonOnly
+        case "firstpersononly":
+            self = .firstPersonOnly
+        default:
+            return nil
+        }
+    }
+
+    func isHidden(in mode: FirstPersonRenderMode) -> Bool {
+        switch (self, mode) {
+        case (.firstPersonOnly, .thirdPerson),
+             (.thirdPersonOnly, .firstPerson):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+private extension Material {
+    func currentColor(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float> {
+        switch self {
+        case let material as UnlitMaterial:
+            return material.color.tint.simd
+        case let material as PhysicallyBasedMaterial:
+            switch type {
+            case .color:
+                return material.baseColor.tint.simd
+            case .emissionColor:
+                return material.emissiveColor.color.simd
+            case .shadeColor:
+                return material.baseColor.tint.simd
+            case .matcapColor, .rimColor:
+                return material.emissiveColor.color.simd
+            case .outlineColor:
+                return material.baseColor.tint.simd
+            }
+        default:
+            return SIMD4<Float>(1, 1, 1, 1)
+        }
+    }
+
+    func settingColor(_ color: VRMColor,
+                      for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> Material {
+        switch self {
+        case var material as UnlitMaterial:
+            material.color.tint = color
+            return material
+        case var material as PhysicallyBasedMaterial:
+            switch type {
+            case .color, .shadeColor, .outlineColor:
+                material.baseColor.tint = color
+            case .emissionColor:
+                material.emissiveColor.color = color
+            case .matcapColor, .rimColor:
+                material.emissiveColor.color = color
+            }
+            return material
+        default:
+            return self
+        }
+    }
+}
+
+private extension VRMColor {
+    convenience init(simd color: SIMD4<Float>) {
+        self.init(red: CGFloat(color.x),
+                  green: CGFloat(color.y),
+                  blue: CGFloat(color.z),
+                  alpha: CGFloat(color.w))
+    }
+
+    var simd: SIMD4<Float> {
+        #if os(macOS)
+        let color = usingColorSpace(.deviceRGB) ?? self
+        return SIMD4<Float>(Float(color.redComponent),
+                            Float(color.greenComponent),
+                            Float(color.blueComponent),
+                            Float(color.alphaComponent))
+        #else
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return SIMD4<Float>(Float(red), Float(green), Float(blue), Float(alpha))
+        #endif
+    }
+}
+
+private extension SIMD4 where Scalar == Float {
+    init(_ values: [Double], defaultAlpha: Float) {
+        self.init(Float(values[safe: 0] ?? 0),
+                  Float(values[safe: 1] ?? 0),
+                  Float(values[safe: 2] ?? 0),
+                  Float(values[safe: 3] ?? Double(defaultAlpha)))
     }
 }
 #endif

--- a/Sources/VRMRealityKit/CustomType/VRMEntity.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntity.swift
@@ -122,15 +122,21 @@ public final class VRMEntity {
                       let type = FirstPersonAnnotationType(vrm0Flag: annotation.firstPersonFlag) else {
                     return nil
                 }
-                return FirstPersonAnnotation(entity: mesh, type: type)
+                return FirstPersonAnnotation(entity: mesh,
+                                             type: type,
+                                             hidesAutoInFirstPerson: false)
             }
         case .v1(let vrm1):
+            let head = humanoid.node(for: .head)
             firstPersonAnnotations = vrm1.firstPerson?.meshAnnotations.compactMap { annotation in
                 guard nodes.indices.contains(annotation.node),
                       let node = nodes[annotation.node] else {
                     return nil
                 }
-                return FirstPersonAnnotation(entity: node, type: FirstPersonAnnotationType(vrm1Type: annotation.type))
+                let type = FirstPersonAnnotationType(vrm1Type: annotation.type)
+                return FirstPersonAnnotation(entity: node,
+                                             type: type,
+                                             hidesAutoInFirstPerson: type == .auto && node.isSameOrDescendant(of: head))
             } ?? []
         }
         setFirstPersonRenderMode(.thirdPerson)
@@ -339,7 +345,8 @@ public final class VRMEntity {
 
     public func setFirstPersonRenderMode(_ mode: FirstPersonRenderMode) {
         for annotation in firstPersonAnnotations {
-            annotation.entity.isEnabled = !annotation.type.isHidden(in: mode)
+            annotation.entity.isEnabled = !annotation.type.isHidden(in: mode,
+                                                                    hidesAutoInFirstPerson: annotation.hidesAutoInFirstPerson)
         }
     }
 
@@ -635,6 +642,7 @@ private struct MaterialColorBinding {
 private struct FirstPersonAnnotation {
     let entity: Entity
     let type: FirstPersonAnnotationType
+    let hidesAutoInFirstPerson: Bool
 }
 
 private enum FirstPersonAnnotationType {
@@ -667,14 +675,31 @@ private enum FirstPersonAnnotationType {
         }
     }
 
-    func isHidden(in mode: FirstPersonRenderMode) -> Bool {
+    func isHidden(in mode: FirstPersonRenderMode, hidesAutoInFirstPerson: Bool) -> Bool {
         switch (self, mode) {
+        case (.auto, .firstPerson):
+            return hidesAutoInFirstPerson
         case (.firstPersonOnly, .thirdPerson),
              (.thirdPersonOnly, .firstPerson):
             return true
         default:
             return false
         }
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+private extension Entity {
+    func isSameOrDescendant(of ancestor: Entity?) -> Bool {
+        guard let ancestor else { return false }
+        var entity: Entity? = self
+        while let current = entity {
+            if current === ancestor {
+                return true
+            }
+            entity = current.parent
+        }
+        return false
     }
 }
 

--- a/Sources/VRMRealityKit/CustomType/VRMEntitySpringBone.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntitySpringBone.swift
@@ -7,9 +7,47 @@ import Foundation
 @available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 @MainActor
 final class VRMEntitySpringBone {
-    struct SphereCollider {
-        let position: SIMD3<Float>
+    struct Collider {
+        let head: SIMD3<Float>
+        let tail: SIMD3<Float>?
         let radius: Float
+
+        func closestPoint(to point: SIMD3<Float>) -> SIMD3<Float> {
+            guard let tail else { return head }
+            let segment = tail - head
+            let lengthSquared = segment.length_squared
+            guard lengthSquared > 0 else { return head }
+            let t = max(0, min(1, simd_dot(point - head, segment) / lengthSquared))
+            return head + segment * t
+        }
+    }
+
+    struct JointSetting {
+        let stiffnessForce: Float
+        let gravityPower: Float
+        let gravityDir: SIMD3<Float>
+        let dragForce: Float
+        let hitRadius: Float
+
+        init(stiffnessForce: Float = 1.0,
+             gravityPower: Float = 0.0,
+             gravityDir: SIMD3<Float> = .init(0, -1, 0),
+             dragForce: Float = 0.4,
+             hitRadius: Float = 0.02) {
+            self.stiffnessForce = stiffnessForce
+            self.gravityPower = gravityPower
+            self.gravityDir = gravityDir
+            self.dragForce = dragForce
+            self.hitRadius = hitRadius
+        }
+
+        init(joint: VRM1.SpringBone.Spring.Joint) {
+            self.init(stiffnessForce: Float(joint.stiffness ?? 1.0),
+                      gravityPower: Float(joint.gravityPower ?? 0.0),
+                      gravityDir: SIMD3<Float>(joint.gravityDir, defaultValue: SIMD3<Float>(0, -1, 0)),
+                      dragForce: Float(joint.dragForce ?? 0.5),
+                      hitRadius: Float(joint.hitRadius ?? 0.02))
+        }
     }
 
     public let comment: String?
@@ -24,7 +62,9 @@ final class VRMEntitySpringBone {
     private var initialLocalRotations: [(Entity, simd_quatf)] = []
     private let colliderGroups: [VRMEntitySpringBoneColliderGroup]
     private var verlet: [VRMEntitySpringBoneLogic] = []
-    private var colliderList: [SphereCollider] = []
+    private var colliderList: [Collider] = []
+    private let jointChain: [Entity]?
+    private let jointSettings: [ObjectIdentifier: JointSetting]
 
     init(center: Entity?,
          rootBones: [Entity],
@@ -34,6 +74,8 @@ final class VRMEntitySpringBone {
          gravityDir: SIMD3<Float> = .init(0, -1, 0),
          dragForce: Float = 0.4,
          hitRadius: Float = 0.02,
+         jointChain: [Entity]? = nil,
+         jointSettings: [ObjectIdentifier: JointSetting] = [:],
          colliderGroups: [VRMEntitySpringBoneColliderGroup] = []) {
         self.center = center
         self.rootBones = rootBones
@@ -43,6 +85,8 @@ final class VRMEntitySpringBone {
         self.gravityDir = gravityDir
         self.dragForce = dragForce
         self.hitRadius = hitRadius
+        self.jointChain = jointChain
+        self.jointSettings = jointSettings
         self.colliderGroups = colliderGroups
         setup()
     }
@@ -54,11 +98,18 @@ final class VRMEntitySpringBone {
         initialLocalRotations = []
         verlet = []
 
-        for root in rootBones {
-            enumerateHierarchy(root) { node in
+        if let jointChain, !jointChain.isEmpty {
+            for node in jointChain {
                 initialLocalRotations.append((node, node.utx.localRotation))
             }
-            setupRecursive(center, root)
+            setupChain(center, jointChain)
+        } else {
+            for root in rootBones {
+                enumerateHierarchy(root) { node in
+                    initialLocalRotations.append((node, node.utx.localRotation))
+                }
+                setupRecursive(center, root)
+            }
         }
     }
 
@@ -97,6 +148,28 @@ final class VRMEntitySpringBone {
         }
     }
 
+    private func setupChain(_ center: Entity?, _ joints: [Entity]) {
+        for index in joints.indices {
+            let joint = joints[index]
+            let localChildPosition: SIMD3<Float>
+            if joints.indices.contains(index + 1) {
+                localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(joints[index + 1].utx.position)
+            } else if let firstChild = joint.children.first {
+                localChildPosition = firstChild.utx.localPosition * firstChild.utx.lossyScale
+            } else if let parent = joint.parent {
+                let delta = joint.utx.position - parent.utx.position
+                let childPosition = joint.utx.position + delta.normalized * 0.07
+                localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(childPosition)
+            } else {
+                continue
+            }
+            let logic = VRMEntitySpringBoneLogic(center: center,
+                                                 node: joint,
+                                                 localChildPosition: localChildPosition)
+            verlet.append(logic)
+        }
+    }
+
     func update(deltaTime: TimeInterval) {
         if verlet.isEmpty {
             if rootBones.isEmpty {
@@ -108,21 +181,22 @@ final class VRMEntitySpringBone {
         colliderList = []
         for group in colliderGroups {
             for collider in group.colliders {
-                colliderList.append(SphereCollider(
-                    position: group.node.utx.transformPoint(collider.offset),
-                    radius: collider.radius
-                ))
+                colliderList.append(collider.worldCollider)
             }
         }
 
-        let stiffness = stiffnessForce * Float(deltaTime)
-        let external = gravityDir * (gravityPower * Float(deltaTime))
-
         for logic in verlet {
-            logic.radius = hitRadius
+            let setting = jointSettings[ObjectIdentifier(logic.head)] ?? JointSetting(stiffnessForce: stiffnessForce,
+                                                                                      gravityPower: gravityPower,
+                                                                                      gravityDir: gravityDir,
+                                                                                      dragForce: dragForce,
+                                                                                      hitRadius: hitRadius)
+            let stiffness = setting.stiffnessForce * Float(deltaTime)
+            let external = setting.gravityDir * (setting.gravityPower * Float(deltaTime))
+            logic.radius = setting.hitRadius
             logic.update(center: center,
                          stiffnessForce: stiffness,
-                         dragForce: dragForce,
+                         dragForce: setting.dragForce,
                          external: external,
                          colliders: colliderList)
         }
@@ -159,7 +233,7 @@ extension VRMEntitySpringBone {
                     stiffnessForce: Float,
                     dragForce: Float,
                     external: SIMD3<Float>,
-                    colliders: [SphereCollider]) {
+                    colliders: [Collider]) {
             let currentTail: SIMD3<Float> = center?.utx.transformPoint(self.currentTail) ?? self.currentTail
             let prevTail: SIMD3<Float> = center?.utx.transformPoint(self.prevTail) ?? self.prevTail
 
@@ -185,18 +259,26 @@ extension VRMEntitySpringBone {
             return simd_quatf(from: rotation * boneAxis, to: nextTail - node.utx.position) * rotation
         }
 
-        private func collision(_ colliders: [SphereCollider], _ nextTail: SIMD3<Float>) -> SIMD3<Float> {
+        private func collision(_ colliders: [Collider], _ nextTail: SIMD3<Float>) -> SIMD3<Float> {
             var nextTail = nextTail
             for collider in colliders {
+                let colliderPosition = collider.closestPoint(to: nextTail)
                 let r = radius + collider.radius
-                if (nextTail - collider.position).length_squared <= (r * r) {
-                    let normal = (nextTail - collider.position).normalized
-                    let posFromCollider = collider.position + normal * (radius + collider.radius)
+                if (nextTail - colliderPosition).length_squared <= (r * r) {
+                    let normal = (nextTail - colliderPosition).normalized
+                    let posFromCollider = colliderPosition + normal * (radius + collider.radius)
                     nextTail = node.utx.position + (posFromCollider - node.utx.position).normalized * length
                 }
             }
             return nextTail
         }
+    }
+}
+private extension SIMD3 where Scalar == Float {
+    init(_ values: [Double]?, defaultValue: SIMD3<Float>) {
+        self.init(Float(values?[safe: 0] ?? Double(defaultValue.x)),
+                  Float(values?[safe: 1] ?? Double(defaultValue.y)),
+                  Float(values?[safe: 2] ?? Double(defaultValue.z)))
     }
 }
 #endif

--- a/Sources/VRMRealityKit/CustomType/VRMEntitySpringBone.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntitySpringBone.swift
@@ -124,7 +124,8 @@ final class VRMEntitySpringBone {
         if parent.utx.childCount == 0 {
             guard let parentNode = parent.parent else { return }
             let delta = parent.utx.position - parentNode.utx.position
-            let childPosition = parent.utx.position + delta.normalized * 0.07
+            let direction = delta.length_squared > Float.ulpOfOne ? delta.normalized : SIMD3<Float>(0, -1, 0)
+            let childPosition = parent.utx.position + direction * 0.07
             let localChild = parent.utx.worldToLocalMatrix.multiplyPoint(childPosition)
             let logic = VRMEntitySpringBoneLogic(center: center,
                                                  node: parent,
@@ -158,7 +159,8 @@ final class VRMEntitySpringBone {
                 localChildPosition = firstChild.utx.localPosition * firstChild.utx.lossyScale
             } else if let parent = joint.parent {
                 let delta = joint.utx.position - parent.utx.position
-                let childPosition = joint.utx.position + delta.normalized * 0.07
+                let direction = delta.length_squared > Float.ulpOfOne ? delta.normalized : SIMD3<Float>(0, -1, 0)
+                let childPosition = joint.utx.position + direction * 0.07
                 localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(childPosition)
             } else {
                 continue

--- a/Sources/VRMRealityKit/CustomType/VRMEntitySpringBone.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntitySpringBone.swift
@@ -132,15 +132,10 @@ final class VRMEntitySpringBone {
                                                  localChildPosition: localChild)
             verlet.append(logic)
         } else if let firstChild = parent.children.first {
-            let localPosition = firstChild.utx.localPosition
-            let scale = firstChild.utx.lossyScale
+            let localChildPosition = parent.utx.worldToLocalMatrix.multiplyPoint(firstChild.utx.position)
             let logic = VRMEntitySpringBoneLogic(center: center,
                                                  node: parent,
-                                                 localChildPosition: SIMD3<Float>(
-                                                    localPosition.x * scale.x,
-                                                    localPosition.y * scale.y,
-                                                    localPosition.z * scale.z
-                                                 ))
+                                                 localChildPosition: localChildPosition)
             verlet.append(logic)
         }
 
@@ -156,7 +151,7 @@ final class VRMEntitySpringBone {
             if joints.indices.contains(index + 1) {
                 localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(joints[index + 1].utx.position)
             } else if let firstChild = joint.children.first {
-                localChildPosition = firstChild.utx.localPosition * firstChild.utx.lossyScale
+                localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(firstChild.utx.position)
             } else if let parent = joint.parent {
                 let delta = joint.utx.position - parent.utx.position
                 let direction = delta.length_squared > Float.ulpOfOne ? delta.normalized : SIMD3<Float>(0, -1, 0)

--- a/Sources/VRMRealityKit/CustomType/VRMEntitySpringBoneColliderGroup.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntitySpringBoneColliderGroup.swift
@@ -5,23 +5,67 @@ import VRMKit
 @available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 @MainActor
 final class VRMEntitySpringBoneColliderGroup {
-    let node: Entity
-    let colliders: [SphereCollider]
+    let colliders: [Collider]
 
     init(colliderGroup: VRM0.SecondaryAnimation.ColliderGroup, loader: VRMEntityLoader) throws {
-        self.node = try loader.node(withNodeIndex: colliderGroup.node)
-        self.colliders = colliderGroup.colliders.map(SphereCollider.init)
+        let node = try loader.node(withNodeIndex: colliderGroup.node)
+        self.colliders = colliderGroup.colliders.map { Collider(node: node, collider: $0) }
     }
 
-    final class SphereCollider {
+    init(colliderGroup: VRM1.SpringBone.ColliderGroup,
+         springBone: VRM1.SpringBone,
+         loader: VRMEntityLoader) throws {
+        let sourceColliders = springBone.colliders ?? []
+        self.colliders = try colliderGroup.colliders.compactMap { colliderIndex in
+            guard sourceColliders.indices.contains(colliderIndex) else { return nil }
+            return try Collider(collider: sourceColliders[colliderIndex], loader: loader)
+        }
+    }
+
+    @MainActor
+    final class Collider {
+        let node: Entity
         let offset: SIMD3<Float>
+        let tail: SIMD3<Float>?
         let radius: Float
 
-        init(collider: VRM0.SecondaryAnimation.ColliderGroup.Collider) {
+        var worldCollider: VRMEntitySpringBone.Collider {
+            VRMEntitySpringBone.Collider(head: node.utx.transformPoint(offset),
+                                         tail: tail.map(node.utx.transformPoint),
+                                         radius: radius)
+        }
+
+        init(node: Entity, collider: VRM0.SecondaryAnimation.ColliderGroup.Collider) {
+            self.node = node
             self.offset = SIMD3<Float>(Float(collider.offset.x), Float(collider.offset.y), Float(collider.offset.z))
+            self.tail = nil
             self.radius = Float(collider.radius)
+        }
+
+        init(collider: VRM1.SpringBone.Collider, loader: VRMEntityLoader) throws {
+            self.node = try loader.node(withNodeIndex: collider.node)
+            if let sphere = collider.shape.sphere {
+                self.offset = SIMD3<Float>(sphere.offset, defaultValue: .zero)
+                self.tail = nil
+                self.radius = Float(sphere.radius)
+            } else if let capsule = collider.shape.capsule {
+                self.offset = SIMD3<Float>(capsule.offset, defaultValue: .zero)
+                self.tail = SIMD3<Float>(capsule.tail, defaultValue: .zero)
+                self.radius = Float(capsule.radius)
+            } else {
+                self.offset = .zero
+                self.tail = nil
+                self.radius = 0
+            }
         }
     }
 }
-#endif
 
+private extension SIMD3 where Scalar == Float {
+    init(_ values: [Double], defaultValue: SIMD3<Float>) {
+        self.init(Float(values[safe: 0] ?? Double(defaultValue.x)),
+                  Float(values[safe: 1] ?? Double(defaultValue.y)),
+                  Float(values[safe: 2] ?? Double(defaultValue.z)))
+    }
+}
+#endif

--- a/Sources/VRMRealityKit/VRMEntityLoader.swift
+++ b/Sources/VRMRealityKit/VRMEntityLoader.swift
@@ -46,20 +46,32 @@ open class VRMEntityLoader {
             vrmEntity.entity.addChild(try self.node(withNodeIndex: node))
         }
         vrmEntity.setUpHumanoid(nodes: entityData.nodes)
-        vrmEntity.setUpBlendShapes(meshes: entityData.meshes)
+        try vrmEntity.setUpBlendShapes(nodes: entityData.nodes, meshes: entityData.meshes, loader: self)
+        vrmEntity.setUpFirstPerson(nodes: entityData.nodes, meshes: entityData.meshes)
+        try vrmEntity.setUpNodeConstraints(gltfNodes: try gltf.load(\.nodes), loader: self)
         try vrmEntity.setUpSpringBones(loader: self)
-        // TODO: Constraints, animations.
+        // TODO: animations.
 
         entityData.entities[index] = vrmEntity
         return vrmEntity
     }
 
     public func loadThumbnail() throws -> VRMImage {
-        guard let textureIndex = vrm.meta.texture, textureIndex >= 0 else {
-            throw VRMError.thumbnailNotFound
+        switch vrm {
+        case .v0(let vrm0):
+            guard let textureIndex = vrm0.meta.texture, textureIndex >= 0 else {
+                throw VRMError.thumbnailNotFound
+            }
+            let texture = try gltf.load(\.textures)[textureIndex]
+            if let cache = try entityData.load(\.images, index: texture.source) { return cache }
+            return try image(withImageIndex: texture.source)
+        case .v1(let vrm1):
+            guard let imageIndex = vrm1.meta.thumbnailImage, imageIndex >= 0 else {
+                throw VRMError.thumbnailNotFound
+            }
+            if let cache = try entityData.load(\.images, index: imageIndex) { return cache }
+            return try image(withImageIndex: imageIndex)
         }
-        if let cache = try entityData.load(\.images, index: textureIndex) { return cache }
-        return try image(withImageIndex: textureIndex)
     }
 
     func node(withNodeIndex index: Int) throws -> Entity {
@@ -128,7 +140,9 @@ open class VRMEntityLoader {
 
     func mesh(withMeshIndex index: Int, skinIndex: Int?) throws -> Entity {
         if skinIndex == nil, let cache = try entityData.load(\.meshes, index: index) {
-            return cache.clone(recursive: true)
+            let clone = cache.clone(recursive: true)
+            registerMaterialBindings(in: clone)
+            return clone
         }
 
         let gltfMesh = try gltf.load(\.meshes)[index]
@@ -163,11 +177,14 @@ open class VRMEntityLoader {
 
         if skinIndex == nil {
             entityData.meshes[index] = meshEntity
-            return meshEntity.clone(recursive: true)
+            let clone = meshEntity.clone(recursive: true)
+            registerMaterialBindings(in: clone)
+            return clone
         }
         if entityData.meshes.indices.contains(index), entityData.meshes[index] == nil {
             entityData.meshes[index] = meshEntity
         }
+        registerMaterialBindings(in: meshEntity)
         return meshEntity
     }
 
@@ -329,6 +346,9 @@ open class VRMEntityLoader {
         }
 
         let modelEntity = ModelEntity(mesh: mesh, materials: [material])
+        if let materialIndex = primitive.material {
+            modelEntity.components.set(VRMMaterialIndexComponent(materialIndex: materialIndex))
+        }
         if hasBlendShapes {
             let mapping = BlendShapeWeightsMapping(meshResource: mesh)
             modelEntity.components.set(BlendShapeWeightsComponent(weightsMapping: mapping))
@@ -396,8 +416,9 @@ open class VRMEntityLoader {
         let gltfMaterial = try gltf.load(\.materials)[index]
 
         let materialProperty: VRM0.MaterialProperty? = {
-            guard let name = gltfMaterial.name else { return nil }
-            return vrm.materialPropertyNameMap[name]
+            guard case .v0(let vrm0) = vrm,
+                  let name = gltfMaterial.name else { return nil }
+            return vrm0.materialPropertyNameMap[name]
         }()
         let shaderName = materialProperty?.shader.lowercased()
         // MToon / Unlit variants are not PBR, so use UnlitMaterial for consistent rendering
@@ -1344,6 +1365,18 @@ open class VRMEntityLoader {
         vrmEntity.registerSkinBinding(modelEntity: modelEntity,
                                       skeleton: skeleton,
                                       jointEntities: jointEntities)
+    }
+
+    private func registerMaterialBindings(in root: Entity) {
+        guard let vrmEntity = currentEntity else { return }
+        var stack: [Entity] = [root]
+        while let entity = stack.popLast() {
+            if let modelEntity = entity as? ModelEntity,
+               let materialIndex = modelEntity.components[VRMMaterialIndexComponent.self]?.materialIndex {
+                vrmEntity.registerMaterialBinding(modelEntity: modelEntity, materialIndex: materialIndex)
+            }
+            stack.append(contentsOf: entity.children)
+        }
     }
 
     private func transform(from node: GLTF.Node) -> Transform {

--- a/Sources/VRMRealityKit/VRMEntityLoader.swift
+++ b/Sources/VRMRealityKit/VRMEntityLoader.swift
@@ -62,11 +62,23 @@ open class VRMEntityLoader {
             guard let textureIndex = vrm0.meta.texture, textureIndex >= 0 else {
                 throw VRMError.thumbnailNotFound
             }
-            let texture = try gltf.load(\.textures)[textureIndex]
+            let textures = try gltf.load(\.textures)
+            guard textures.indices.contains(textureIndex) else {
+                throw VRMError.thumbnailNotFound
+            }
+            let texture = textures[textureIndex]
+            let images = try gltf.load(\.images)
+            guard images.indices.contains(texture.source) else {
+                throw VRMError.thumbnailNotFound
+            }
             if let cache = try entityData.load(\.images, index: texture.source) { return cache }
             return try image(withImageIndex: texture.source)
         case .v1(let vrm1):
             guard let imageIndex = vrm1.meta.thumbnailImage, imageIndex >= 0 else {
+                throw VRMError.thumbnailNotFound
+            }
+            let images = try gltf.load(\.images)
+            guard images.indices.contains(imageIndex) else {
                 throw VRMError.thumbnailNotFound
             }
             if let cache = try entityData.load(\.images, index: imageIndex) { return cache }
@@ -413,7 +425,11 @@ open class VRMEntityLoader {
 
     func material(withMaterialIndex index: Int) throws -> Material {
         if let cache = try entityData.load(\.materials, index: index) { return cache }
-        let gltfMaterial = try gltf.load(\.materials)[index]
+        let materials = try gltf.load(\.materials)
+        guard materials.indices.contains(index) else {
+            throw VRMError._dataInconsistent("Material index \(index) out of bounds")
+        }
+        let gltfMaterial = materials[index]
 
         let materialProperty: VRM0.MaterialProperty? = {
             guard case .v0(let vrm0) = vrm,

--- a/Sources/VRMSceneKit/CustomType/VRMNode.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMNode.swift
@@ -1,4 +1,5 @@
 import SceneKit
+import simd
 import VRMKit
 import VRMKitRuntime
 
@@ -10,6 +11,10 @@ open class VRMNode: SCNNode {
     private var springBones: [VRMSpringBone] = []
 
     var blendShapeClips: [BlendShapeKey: BlendShapeClip] = [:]
+    private var materialColorClips: [BlendShapeKey: [MaterialColorBinding]] = [:]
+    private var textureTransformClips: [BlendShapeKey: [TextureTransformBinding]] = [:]
+    private var firstPersonAnnotations: [FirstPersonAnnotation] = []
+    private var nodeConstraints: [NodeConstraintBinding] = []
 
     public init(vrm: VRM) {
         self.vrm = vrm
@@ -21,47 +26,192 @@ open class VRMNode: SCNNode {
     }
 
     func setUpHumanoid(nodes: [SCNNode?]) {
-        humanoid.setUp(humanoid: vrm.humanoid, nodes: nodes)
+        switch vrm {
+        case .v0:
+            humanoid.setUp(humanoid: vrm.humanoid, nodes: nodes)
+        case .v1(let vrm1):
+            humanoid.setUp(humanoid: vrm1.humanoid, nodes: nodes)
+        }
     }
 
-    func setUpBlendShapes(meshes: [SCNNode?]) {
-        blendShapeClips = vrm.blendShapeMaster.blendShapeGroups
-            .map { group in
-                let blendShapeBinding: [BlendShapeBinding] = group.binds?
-                    .compactMap {
-                        guard let mesh = meshes[$0.mesh] else {
+    func setUpBlendShapes(nodes: [SCNNode?], meshes: [SCNNode?], loader: VRMSceneLoader) throws {
+        blendShapeClips = [:]
+        materialColorClips = [:]
+        textureTransformClips = [:]
+
+        switch vrm {
+        case .v0:
+            blendShapeClips = vrm.blendShapeMaster.blendShapeGroups
+                .map { group in
+                    let blendShapeBinding: [BlendShapeBinding] = group.binds?
+                        .compactMap {
+                            guard meshes.indices.contains($0.mesh),
+                                  let mesh = meshes[$0.mesh] else {
+                                return nil
+                            }
+                            return BlendShapeBinding(mesh: mesh, index: $0.index, weight: $0.weight)
+                        } ?? []
+                    return BlendShapeClip(name: group.name,
+                                          preset: BlendShapePreset(name: group.presetName),
+                                          values: blendShapeBinding,
+                                          isBinary: group.isBinary)
+                }
+                .reduce(into: [:]) { result, clip in
+                    result[clip.key] = clip
+                }
+        case .v1(let vrm1):
+            guard let expressions = vrm1.expressions else { return }
+            for expressionClip in expressions.runtimeClips {
+                let morphBindings: [BlendShapeBinding] = expressionClip.expression.morphTargetBinds?
+                    .compactMap { bind in
+                        guard nodes.indices.contains(bind.node),
+                              let node = nodes[bind.node] else {
                             return nil
                         }
-                        return BlendShapeBinding(mesh: mesh, index: $0.index, weight: $0.weight)
+                        return BlendShapeBinding(mesh: node, index: bind.index, weight: bind.weight * 100.0)
                     } ?? []
-                return BlendShapeClip(name: group.name,
-                                      preset: BlendShapePreset(name: group.presetName),
-                                      values: blendShapeBinding,
-                                      isBinary: group.isBinary)
+                let clip = BlendShapeClip(name: expressionClip.name,
+                                          preset: expressionClip.preset,
+                                          values: morphBindings,
+                                          isBinary: expressionClip.expression.isBinary ?? false)
+                blendShapeClips[clip.key] = clip
+
+                let colorBindings: [MaterialColorBinding] = try expressionClip.expression.materialColorBinds?
+                    .compactMap { bind in
+                        guard bind.targetValue.count >= 3 else { return nil }
+                        let material = try loader.material(withMaterialIndex: bind.material)
+                        return MaterialColorBinding(material: material,
+                                                    type: bind.type,
+                                                    targetValue: SIMD4<Float>(bind.targetValue, defaultAlpha: 1.0),
+                                                    baseValue: material.currentColor(for: bind.type))
+                    } ?? []
+                if !colorBindings.isEmpty {
+                    materialColorClips[clip.key] = colorBindings
+                }
+
+                let transformBindings: [TextureTransformBinding] = try expressionClip.expression.textureTransformBinds?
+                    .compactMap { bind in
+                        let material = try loader.material(withMaterialIndex: bind.material)
+                        let base = material.diffuse.scaleOffset
+                        return TextureTransformBinding(material: material,
+                                                       baseScale: base.scale,
+                                                       baseOffset: base.offset,
+                                                       targetScale: SIMD2<Float>(bind.scale, defaultValue: 1.0),
+                                                       targetOffset: SIMD2<Float>(bind.offset, defaultValue: 0.0))
+                    } ?? []
+                if !transformBindings.isEmpty {
+                    textureTransformClips[clip.key] = transformBindings
+                }
             }
-            .reduce(into: [:]) { result, clip in
-                result[clip.key] = clip
         }
+    }
+
+    func setUpFirstPerson(nodes: [SCNNode?], meshes: [SCNNode?]) {
+        switch vrm {
+        case .v0:
+            firstPersonAnnotations = vrm.firstPerson.meshAnnotations.compactMap { annotation in
+                guard meshes.indices.contains(annotation.mesh),
+                      let mesh = meshes[annotation.mesh],
+                      let type = FirstPersonAnnotationType(vrm0Flag: annotation.firstPersonFlag) else {
+                    return nil
+                }
+                return FirstPersonAnnotation(node: mesh, type: type)
+            }
+        case .v1(let vrm1):
+            firstPersonAnnotations = vrm1.firstPerson?.meshAnnotations.compactMap { annotation in
+                guard nodes.indices.contains(annotation.node),
+                      let node = nodes[annotation.node] else {
+                    return nil
+                }
+                return FirstPersonAnnotation(node: node, type: FirstPersonAnnotationType(vrm1Type: annotation.type))
+            } ?? []
+        }
+        setFirstPersonRenderMode(.thirdPerson)
+    }
+
+    func setUpNodeConstraints(gltfNodes: [GLTF.Node], loader: VRMSceneLoader) throws {
+        guard case .v1 = vrm else {
+            nodeConstraints = []
+            return
+        }
+
+        var bindings: [NodeConstraintBinding] = []
+        for (targetIndex, gltfNode) in gltfNodes.enumerated() {
+            guard let constraint = gltfNode.extensions?.nodeConstraint?.constraint,
+                  let descriptor = VRMNodeConstraintDescriptor(constraint) else {
+                continue
+            }
+            let sourceIndex = descriptor.source
+            guard sourceIndex != targetIndex else {
+                throw VRMError._dataInconsistent("VRMC_node_constraint source must not be destination: \(targetIndex)")
+            }
+            guard gltfNodes.indices.contains(sourceIndex) else {
+                throw VRMError._dataInconsistent("VRMC_node_constraint source index is out of range: \(sourceIndex)")
+            }
+
+            let target = try loader.node(withNodeIndex: targetIndex)
+            let source = try loader.node(withNodeIndex: sourceIndex)
+            bindings.append(NodeConstraintBinding(targetIndex: targetIndex,
+                                                  sourceIndex: sourceIndex,
+                                                  descriptor: descriptor,
+                                                  target: target,
+                                                  source: source))
+        }
+        nodeConstraints = try NodeConstraintBinding.ordered(bindings)
     }
     
     func setUpSpringBones(loader: VRMSceneLoader) throws {
         var springBones: [VRMSpringBone] = []
-        let secondaryAnimation = vrm.secondaryAnimation
-        for boneGroup in secondaryAnimation.boneGroups {
-            guard !boneGroup.bones.isEmpty else { return }
-            let rootBones: [SCNNode] = try boneGroup.bones.compactMap({ try loader.node(withNodeIndex: $0) }).compactMap({ $0 })
-            let centerNode = try? loader.node(withNodeIndex: boneGroup.center)
-            let colliderGroups = try secondaryAnimation.colliderGroups.map({ try VRMSpringBoneColliderGroup(colliderGroup: $0, loader: loader) })
-            let springBone = VRMSpringBone(center: centerNode,
-                                           rootBones: rootBones,
-                                           comment: boneGroup.comment,
-                                           stiffnessForce: Float(boneGroup.stiffiness),
-                                           gravityPower: Float(boneGroup.gravityPower),
-                                           gravityDir: boneGroup.gravityDir.simd,
-                                           dragForce: Float(boneGroup.dragForce),
-                                           hitRadius: Float(boneGroup.hitRadius),
-                                           colliderGroups: colliderGroups)
-            springBones.append(springBone)
+        switch vrm {
+        case .v0:
+            let secondaryAnimation = vrm.secondaryAnimation
+            let allColliderGroups = try secondaryAnimation.colliderGroups.map {
+                try VRMSpringBoneColliderGroup(colliderGroup: $0, loader: loader)
+            }
+            for boneGroup in secondaryAnimation.boneGroups {
+                guard !boneGroup.bones.isEmpty else { continue }
+                let rootBones: [SCNNode] = try boneGroup.bones.compactMap { try loader.node(withNodeIndex: $0) }
+                let centerNode = try? loader.node(withNodeIndex: boneGroup.center)
+                let colliderGroups = boneGroup.colliderGroups.compactMap { index in
+                    allColliderGroups.indices.contains(index) ? allColliderGroups[index] : nil
+                }
+                let springBone = VRMSpringBone(center: centerNode,
+                                               rootBones: rootBones,
+                                               comment: boneGroup.comment,
+                                               stiffnessForce: Float(boneGroup.stiffiness),
+                                               gravityPower: Float(boneGroup.gravityPower),
+                                               gravityDir: boneGroup.gravityDir.simd,
+                                               dragForce: Float(boneGroup.dragForce),
+                                               hitRadius: Float(boneGroup.hitRadius),
+                                               colliderGroups: colliderGroups)
+                springBones.append(springBone)
+            }
+        case .v1(let vrm1):
+            guard let springBone = vrm1.springBone else { break }
+            for spring in springBone.springs ?? [] {
+                let jointNodes = try spring.joints.compactMap { try loader.node(withNodeIndex: $0.node) }
+                guard !jointNodes.isEmpty else { continue }
+                let centerNode = try spring.center.map { try loader.node(withNodeIndex: $0) }
+                let colliderGroups = try spring.colliderGroups?.compactMap { groupIndex -> VRMSpringBoneColliderGroup? in
+                    guard let groups = springBone.colliderGroups,
+                          groups.indices.contains(groupIndex) else {
+                        return nil
+                    }
+                    return try VRMSpringBoneColliderGroup(colliderGroup: groups[groupIndex],
+                                                          springBone: springBone,
+                                                          loader: loader)
+                } ?? []
+                let settings = Dictionary(uniqueKeysWithValues: zip(jointNodes, spring.joints).map { node, joint in
+                    (ObjectIdentifier(node), VRMSpringBone.JointSetting(joint: joint))
+                })
+                let springBone = VRMSpringBone(center: centerNode,
+                                               rootBones: [jointNodes[0]],
+                                               comment: spring.name,
+                                               jointChain: jointNodes,
+                                               jointSettings: settings,
+                                               colliderGroups: colliderGroups)
+                springBones.append(springBone)
+            }
         }
         self.springBones = springBones
     }
@@ -72,14 +222,19 @@ open class VRMNode: SCNNode {
     ///   - value: a weight of the blend shape (0.0 <= value <= 1.0)
     ///   - key: a key of the blend shape
     public func setBlendShape(value: CGFloat, for key: BlendShapeKey) {
-        guard let clip = blendShapeClips[key] else { return }
+        guard let clip = blendShapeClip(for: key) else { return }
         let value: CGFloat = clip.isBinary ? round(value) : value
         for binding in clip.values {
             let weight = CGFloat(binding.weight / 100.0)
-            for primitive in binding.mesh.childNodes {
-                guard let morpher = primitive.morpher else { continue }
+            for morpher in binding.mesh.allMorphers {
                 morpher.setWeight(weight * value, forTargetAt: binding.index)
             }
+        }
+        for binding in materialColorClip(for: key) {
+            binding.apply(value: Float(value))
+        }
+        for binding in textureTransformClip(for: key) {
+            binding.apply(value: Float(value))
         }
     }
 
@@ -88,10 +243,31 @@ open class VRMNode: SCNNode {
     /// - Parameter key: a key of the blend shape
     /// - Returns: a weight of the blend shape
     public func blendShape(for key: BlendShapeKey) -> CGFloat {
-        guard let clip = blendShapeClips[key],
+        guard let clip = blendShapeClip(for: key),
             let binding = clip.values.first,
-            let morpher = binding.mesh.childNodes.lazy.compactMap({ $0.morpher }).first else { return 0 }
+            let morpher = binding.mesh.allMorphers.first else { return 0 }
         return morpher.weight(forTargetAt: binding.index)
+    }
+
+    public func setFirstPersonRenderMode(_ mode: FirstPersonRenderMode) {
+        for annotation in firstPersonAnnotations {
+            annotation.node.isHidden = annotation.type.isHidden(in: mode)
+        }
+    }
+
+    private func blendShapeClip(for key: BlendShapeKey) -> BlendShapeClip? {
+        if let clip = blendShapeClips[key] { return clip }
+        return key.aliases.lazy.compactMap { self.blendShapeClips[$0] }.first
+    }
+
+    private func materialColorClip(for key: BlendShapeKey) -> [MaterialColorBinding] {
+        if let clip = materialColorClips[key] { return clip }
+        return key.aliases.lazy.compactMap { self.materialColorClips[$0] }.first ?? []
+    }
+
+    private func textureTransformClip(for key: BlendShapeKey) -> [TextureTransformBinding] {
+        if let clip = textureTransformClips[key] { return clip }
+        return key.aliases.lazy.compactMap { self.textureTransformClips[$0] }.first ?? []
     }
 }
 
@@ -99,6 +275,255 @@ open class VRMNode: SCNNode {
 extension VRMNode: RenderUpdatable {
     public func update(at time: TimeInterval) {
         let seconds = timer.deltaTime(updateAtTime: time)
+        nodeConstraints.forEach { $0.apply() }
         springBones.forEach({ $0.update(deltaTime: seconds) })
+    }
+}
+
+@available(*, deprecated, message: "Deprecated. Use VRMRealityKit instead.")
+private struct NodeConstraintBinding {
+    let targetIndex: Int
+    let sourceIndex: Int
+    let descriptor: VRMNodeConstraintDescriptor
+    let target: SCNNode
+    let source: SCNNode
+    let targetRestRotation: simd_quatf
+    let sourceRestRotation: simd_quatf
+
+    init(targetIndex: Int,
+         sourceIndex: Int,
+         descriptor: VRMNodeConstraintDescriptor,
+         target: SCNNode,
+         source: SCNNode) {
+        self.targetIndex = targetIndex
+        self.sourceIndex = sourceIndex
+        self.descriptor = descriptor
+        self.target = target
+        self.source = source
+        self.targetRestRotation = target.utx.localRotation
+        self.sourceRestRotation = source.utx.localRotation
+    }
+
+    func apply() {
+        target.utx.localRotation = VRMNodeConstraintRuntime.evaluate(
+            descriptor,
+            sourceRestRotation: sourceRestRotation,
+            sourceLocalRotation: source.utx.localRotation,
+            sourceWorldPosition: source.utx.position,
+            destinationRestRotation: targetRestRotation,
+            destinationParentWorldRotation: target.parent?.utx.rotation ?? quat_identity_float,
+            destinationWorldPosition: target.utx.position
+        )
+    }
+
+    static func ordered(_ bindings: [NodeConstraintBinding]) throws -> [NodeConstraintBinding] {
+        let byTargetIndex = Dictionary(uniqueKeysWithValues: bindings.map { ($0.targetIndex, $0) })
+        var states: [Int: VisitState] = [:]
+        var result: [NodeConstraintBinding] = []
+
+        func visit(_ binding: NodeConstraintBinding) throws {
+            switch states[binding.targetIndex] {
+            case .done:
+                return
+            case .visiting:
+                throw VRMError._dataInconsistent("VRMC_node_constraint circular dependency detected at node \(binding.targetIndex)")
+            case .none:
+                break
+            }
+
+            states[binding.targetIndex] = .visiting
+            if let dependency = byTargetIndex[binding.sourceIndex] {
+                try visit(dependency)
+            }
+            states[binding.targetIndex] = .done
+            result.append(binding)
+        }
+
+        for binding in bindings {
+            try visit(binding)
+        }
+        return result
+    }
+
+    private enum VisitState {
+        case visiting
+        case done
+    }
+}
+
+private struct MaterialColorBinding {
+    let material: SCNMaterial
+    let type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType
+    let targetValue: SIMD4<Float>
+    let baseValue: SIMD4<Float>
+
+    func apply(value: Float) {
+        material.setColor(baseValue + (targetValue - baseValue) * value, for: type)
+    }
+}
+
+private struct TextureTransformBinding {
+    let material: SCNMaterial
+    let baseScale: SIMD2<Float>
+    let baseOffset: SIMD2<Float>
+    let targetScale: SIMD2<Float>
+    let targetOffset: SIMD2<Float>
+
+    func apply(value: Float) {
+        let scale = baseScale + (targetScale - baseScale) * value
+        let offset = baseOffset + (targetOffset - baseOffset) * value
+        material.diffuse.contentsTransform = SCNMatrix4(scale: scale, offset: offset)
+    }
+}
+
+private struct FirstPersonAnnotation {
+    let node: SCNNode
+    let type: FirstPersonAnnotationType
+}
+
+private enum FirstPersonAnnotationType {
+    case auto
+    case both
+    case thirdPersonOnly
+    case firstPersonOnly
+
+    init(vrm1Type: VRM1.FirstPerson.FirstPersonType) {
+        switch vrm1Type {
+        case .auto: self = .auto
+        case .both: self = .both
+        case .thirdPersonOnly: self = .thirdPersonOnly
+        case .firstPersonOnly: self = .firstPersonOnly
+        }
+    }
+
+    init?(vrm0Flag: String) {
+        switch vrm0Flag.replacingOccurrences(of: "_", with: "").lowercased() {
+        case "auto":
+            self = .auto
+        case "both":
+            self = .both
+        case "thirdpersononly":
+            self = .thirdPersonOnly
+        case "firstpersononly":
+            self = .firstPersonOnly
+        default:
+            return nil
+        }
+    }
+
+    func isHidden(in mode: FirstPersonRenderMode) -> Bool {
+        switch (self, mode) {
+        case (.firstPersonOnly, .thirdPerson),
+             (.thirdPersonOnly, .firstPerson):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+private extension SCNNode {
+    var allMorphers: [SCNMorpher] {
+        var result: [SCNMorpher] = []
+        enumerateHierarchy { node, _ in
+            if let morpher = node.morpher {
+                result.append(morpher)
+            }
+        }
+        return result
+    }
+}
+
+private extension SCNMaterial {
+    func currentColor(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float> {
+        colorProperty(for: type).simdColor
+    }
+
+    func setColor(_ color: SIMD4<Float>, for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) {
+        colorProperty(for: type).contents = VRMColor(simd: color)
+    }
+
+    private func colorProperty(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SCNMaterialProperty {
+        switch type {
+        case .color:
+            return diffuse.contents is VRMImage ? multiply : diffuse
+        case .emissionColor:
+            return emission
+        case .shadeColor:
+            return multiply
+        case .matcapColor:
+            return reflective
+        case .rimColor:
+            return selfIllumination
+        case .outlineColor:
+            return transparent
+        }
+    }
+}
+
+private extension SCNMaterialProperty {
+    var simdColor: SIMD4<Float> {
+        guard let color = contents as? VRMColor else {
+            return SIMD4<Float>(1, 1, 1, 1)
+        }
+        return color.simd
+    }
+
+    var scaleOffset: (scale: SIMD2<Float>, offset: SIMD2<Float>) {
+        let transform = contentsTransform
+        return (SIMD2<Float>(Float(transform.m11), Float(transform.m22)),
+                SIMD2<Float>(Float(transform.m41), Float(transform.m42)))
+    }
+}
+
+private extension VRMColor {
+    convenience init(simd color: SIMD4<Float>) {
+        self.init(red: CGFloat(color.x),
+                  green: CGFloat(color.y),
+                  blue: CGFloat(color.z),
+                  alpha: CGFloat(color.w))
+    }
+
+    var simd: SIMD4<Float> {
+        #if os(macOS)
+        let color = usingColorSpace(.deviceRGB) ?? self
+        return SIMD4<Float>(Float(color.redComponent),
+                            Float(color.greenComponent),
+                            Float(color.blueComponent),
+                            Float(color.alphaComponent))
+        #else
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return SIMD4<Float>(Float(red), Float(green), Float(blue), Float(alpha))
+        #endif
+    }
+}
+
+private extension SIMD4 where Scalar == Float {
+    init(_ values: [Double], defaultAlpha: Float) {
+        self.init(Float(values[safe: 0] ?? 0),
+                  Float(values[safe: 1] ?? 0),
+                  Float(values[safe: 2] ?? 0),
+                  Float(values[safe: 3] ?? Double(defaultAlpha)))
+    }
+}
+
+private extension SIMD2 where Scalar == Float {
+    init(_ values: [Double]?, defaultValue: Float) {
+        self.init(Float(values?[safe: 0] ?? Double(defaultValue)),
+                  Float(values?[safe: 1] ?? Double(defaultValue)))
+    }
+}
+
+private extension SCNMatrix4 {
+    init(scale: SIMD2<Float>, offset: SIMD2<Float>) {
+        self = SCNMatrix4Identity
+        m11 = SCNFloat(scale.x)
+        m22 = SCNFloat(scale.y)
+        m41 = SCNFloat(offset.x)
+        m42 = SCNFloat(offset.y)
     }
 }

--- a/Sources/VRMSceneKit/CustomType/VRMNode.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMNode.swift
@@ -317,7 +317,13 @@ private struct NodeConstraintBinding {
     }
 
     static func ordered(_ bindings: [NodeConstraintBinding]) throws -> [NodeConstraintBinding] {
-        let byTargetIndex = Dictionary(uniqueKeysWithValues: bindings.map { ($0.targetIndex, $0) })
+        var byTargetIndex: [Int: NodeConstraintBinding] = [:]
+        for binding in bindings {
+            if byTargetIndex[binding.targetIndex] != nil {
+                throw VRMError._dataInconsistent("Multiple constraints targeting the same node \(binding.targetIndex)")
+            }
+            byTargetIndex[binding.targetIndex] = binding
+        }
         var states: [Int: VisitState] = [:]
         var result: [NodeConstraintBinding] = []
 

--- a/Sources/VRMSceneKit/CustomType/VRMNode.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMNode.swift
@@ -115,15 +115,21 @@ open class VRMNode: SCNNode {
                       let type = FirstPersonAnnotationType(vrm0Flag: annotation.firstPersonFlag) else {
                     return nil
                 }
-                return FirstPersonAnnotation(node: mesh, type: type)
+                return FirstPersonAnnotation(node: mesh,
+                                             type: type,
+                                             hidesAutoInFirstPerson: false)
             }
         case .v1(let vrm1):
+            let head = humanoid.node(for: .head)
             firstPersonAnnotations = vrm1.firstPerson?.meshAnnotations.compactMap { annotation in
                 guard nodes.indices.contains(annotation.node),
                       let node = nodes[annotation.node] else {
                     return nil
                 }
-                return FirstPersonAnnotation(node: node, type: FirstPersonAnnotationType(vrm1Type: annotation.type))
+                let type = FirstPersonAnnotationType(vrm1Type: annotation.type)
+                return FirstPersonAnnotation(node: node,
+                                             type: type,
+                                             hidesAutoInFirstPerson: type == .auto && node.isSameOrDescendant(of: head))
             } ?? []
         }
         setFirstPersonRenderMode(.thirdPerson)
@@ -251,7 +257,8 @@ open class VRMNode: SCNNode {
 
     public func setFirstPersonRenderMode(_ mode: FirstPersonRenderMode) {
         for annotation in firstPersonAnnotations {
-            annotation.node.isHidden = annotation.type.isHidden(in: mode)
+            annotation.node.isHidden = annotation.type.isHidden(in: mode,
+                                                                hidesAutoInFirstPerson: annotation.hidesAutoInFirstPerson)
         }
     }
 
@@ -385,6 +392,7 @@ private struct TextureTransformBinding {
 private struct FirstPersonAnnotation {
     let node: SCNNode
     let type: FirstPersonAnnotationType
+    let hidesAutoInFirstPerson: Bool
 }
 
 private enum FirstPersonAnnotationType {
@@ -417,8 +425,10 @@ private enum FirstPersonAnnotationType {
         }
     }
 
-    func isHidden(in mode: FirstPersonRenderMode) -> Bool {
+    func isHidden(in mode: FirstPersonRenderMode, hidesAutoInFirstPerson: Bool) -> Bool {
         switch (self, mode) {
+        case (.auto, .firstPerson):
+            return hidesAutoInFirstPerson
         case (.firstPersonOnly, .thirdPerson),
              (.thirdPersonOnly, .firstPerson):
             return true
@@ -437,6 +447,18 @@ private extension SCNNode {
             }
         }
         return result
+    }
+
+    func isSameOrDescendant(of ancestor: SCNNode?) -> Bool {
+        guard let ancestor else { return false }
+        var node: SCNNode? = self
+        while let current = node {
+            if current === ancestor {
+                return true
+            }
+            node = current.parent
+        }
+        return false
     }
 }
 

--- a/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
@@ -6,9 +6,47 @@ import VRMKitRuntime
 @available(*, deprecated, message: "Deprecated. Use VRMRealityKit instead.")
 final class VRMSpringBone {
     @available(*, deprecated, message: "Deprecated. Use VRMRealityKit instead.")
-    struct SphereCollider {
-        let position: SIMD3<Float>
+    struct Collider {
+        let head: SIMD3<Float>
+        let tail: SIMD3<Float>?
         let radius: Float
+
+        func closestPoint(to point: SIMD3<Float>) -> SIMD3<Float> {
+            guard let tail else { return head }
+            let segment = tail - head
+            let lengthSquared = segment.length_squared
+            guard lengthSquared > 0 else { return head }
+            let t = max(0, min(1, simd_dot(point - head, segment) / lengthSquared))
+            return head + segment * t
+        }
+    }
+
+    struct JointSetting {
+        let stiffnessForce: Float
+        let gravityPower: Float
+        let gravityDir: SIMD3<Float>
+        let dragForce: Float
+        let hitRadius: Float
+
+        init(stiffnessForce: Float = 1.0,
+             gravityPower: Float = 0.0,
+             gravityDir: SIMD3<Float> = .init(0, -1, 0),
+             dragForce: Float = 0.4,
+             hitRadius: Float = 0.02) {
+            self.stiffnessForce = stiffnessForce
+            self.gravityPower = gravityPower
+            self.gravityDir = gravityDir
+            self.dragForce = dragForce
+            self.hitRadius = hitRadius
+        }
+
+        init(joint: VRM1.SpringBone.Spring.Joint) {
+            self.init(stiffnessForce: Float(joint.stiffness ?? 1.0),
+                      gravityPower: Float(joint.gravityPower ?? 0.0),
+                      gravityDir: SIMD3<Float>(joint.gravityDir, defaultValue: SIMD3<Float>(0, -1, 0)),
+                      dragForce: Float(joint.dragForce ?? 0.5),
+                      hitRadius: Float(joint.hitRadius ?? 0.02))
+        }
     }
     
     public let comment: String?
@@ -23,7 +61,9 @@ final class VRMSpringBone {
     private var initialLocalRotationMap: [SCNNode : simd_quatf] = [:]
     private let colliderGroups: [VRMSpringBoneColliderGroup]
     private var verlet: [VRMSpringBoneLogic] = []
-    private var colliderList: [SphereCollider] = []
+    private var colliderList: [Collider] = []
+    private let jointChain: [SCNNode]?
+    private let jointSettings: [ObjectIdentifier: JointSetting]
     
     private let isDrawGizmo: Bool
     
@@ -35,6 +75,8 @@ final class VRMSpringBone {
          gravityDir: SIMD3<Float> = .init(0, -1, 0),
          dragForce: Float = 0.4,
          hitRadius: Float = 0.02,
+         jointChain: [SCNNode]? = nil,
+         jointSettings: [ObjectIdentifier: JointSetting] = [:],
          colliderGroups: [VRMSpringBoneColliderGroup] = [],
          isDrawGizmo: Bool = false) {
         self.center = center
@@ -46,6 +88,8 @@ final class VRMSpringBone {
         self.dragForce = dragForce
         self.hitRadius = hitRadius
         self.colliderGroups = colliderGroups
+        self.jointChain = jointChain
+        self.jointSettings = jointSettings
         self.isDrawGizmo = isDrawGizmo
         setup()
     }
@@ -57,11 +101,38 @@ final class VRMSpringBone {
         self.initialLocalRotationMap = [:]
         self.verlet = []
 
-        for go in self.rootBones {
-            go.enumerateHierarchy { (x, _) in
-                self.initialLocalRotationMap[x] = x.utx.localRotation
+        if let jointChain, !jointChain.isEmpty {
+            for node in jointChain {
+                initialLocalRotationMap[node] = node.utx.localRotation
             }
-            setupRecursive(self.center, go)
+            setupChain(center, jointChain)
+        } else {
+            for go in self.rootBones {
+                go.enumerateHierarchy { (x, _) in
+                    self.initialLocalRotationMap[x] = x.utx.localRotation
+                }
+                setupRecursive(self.center, go)
+            }
+        }
+    }
+
+    private func setupChain(_ center: SCNNode?, _ joints: [SCNNode]) {
+        for index in joints.indices {
+            let joint = joints[index]
+            let localChildPosition: SIMD3<Float>
+            if joints.indices.contains(index + 1) {
+                localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(joints[index + 1].utx.position)
+            } else if let firstChild = joint.childNodes.first {
+                localChildPosition = firstChild.utx.localPosition * firstChild.utx.lossyScale
+            } else if let parent = joint.parent {
+                let delta = joint.utx.position - parent.utx.position
+                let childPosition = joint.utx.position + delta.normalized * 0.07
+                localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(childPosition)
+            } else {
+                continue
+            }
+            let logic = VRMSpringBoneLogic(center: center, node: joint, localChildPosition: localChildPosition)
+            verlet.append(logic)
         }
     }
     
@@ -105,22 +176,23 @@ final class VRMSpringBone {
         self.colliderList = []
         for group in self.colliderGroups {
             for collider in group.colliders {
-                self.colliderList.append(SphereCollider(
-                    position: group.node.utx.transformPoint(collider.offset),
-                    radius: collider.radius
-                ))
+                self.colliderList.append(collider.worldCollider)
             }
         }
 
-        let stiffness = self.stiffnessForce * Float(deltaTime)
-        let external = self.gravityDir * (self.gravityPower * Float(deltaTime))
-
         for verlet in self.verlet {
-            verlet.radius = self.hitRadius
+            let setting = jointSettings[ObjectIdentifier(verlet.head)] ?? JointSetting(stiffnessForce: stiffnessForce,
+                                                                                       gravityPower: gravityPower,
+                                                                                       gravityDir: gravityDir,
+                                                                                       dragForce: dragForce,
+                                                                                       hitRadius: hitRadius)
+            let stiffness = setting.stiffnessForce * Float(deltaTime)
+            let external = setting.gravityDir * (setting.gravityPower * Float(deltaTime))
+            verlet.radius = setting.hitRadius
             verlet.update(
                 center: self.center,
                 stiffnessForce: stiffness,
-                dragForce: self.dragForce,
+                dragForce: setting.dragForce,
                 external: external,
                 colliders: self.colliderList)
         }
@@ -142,6 +214,14 @@ final class VRMSpringBone {
                 )
             }
         }
+    }
+}
+
+private extension SIMD3 where Scalar == Float {
+    init(_ values: [Double]?, defaultValue: SIMD3<Float>) {
+        self.init(Float(values?[safe: 0] ?? Double(defaultValue.x)),
+                  Float(values?[safe: 1] ?? Double(defaultValue.y)),
+                  Float(values?[safe: 2] ?? Double(defaultValue.z)))
     }
 }
 
@@ -171,7 +251,7 @@ extension VRMSpringBone {
             self.length = localChildPosition.length
         }
         
-        func update(center: SCNNode?, stiffnessForce: Float, dragForce: Float, external: SIMD3<Float>, colliders: [SphereCollider]) {
+        func update(center: SCNNode?, stiffnessForce: Float, dragForce: Float, external: SIMD3<Float>, colliders: [Collider]) {
             let currentTail: SIMD3<Float> = center?.utx.transformPoint(self.currentTail) ?? self.currentTail
             let prevTail: SIMD3<Float> = center?.utx.transformPoint(self.prevTail) ?? self.prevTail
 
@@ -202,14 +282,15 @@ extension VRMSpringBone {
             return simd_quatf(from: rotation * self.boneAxis, to: nextTail - self.node.utx.position) * rotation
         }
         
-        private func collision(_ colliders: [SphereCollider], _ nextTail: SIMD3<Float>) -> SIMD3<Float> {
+        private func collision(_ colliders: [Collider], _ nextTail: SIMD3<Float>) -> SIMD3<Float> {
             var nextTail = nextTail
             for collider in colliders {
+                let colliderPosition = collider.closestPoint(to: nextTail)
                 let r = self.radius + collider.radius
-                if (nextTail - collider.position).length_squared <= (r * r) {
+                if (nextTail - colliderPosition).length_squared <= (r * r) {
                     // ヒット。Colliderの半径方向に押し出す
-                    let normal = (nextTail - collider.position).normalized
-                    let posFromCollider = collider.position + normal * (self.radius + collider.radius)
+                    let normal = (nextTail - colliderPosition).normalized
+                    let posFromCollider = colliderPosition + normal * (self.radius + collider.radius)
                     // 長さをboneLengthに強制
                     nextTail = self.node.utx.position + (posFromCollider - self.node.utx.position).normalized * self.length
                 }

--- a/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
@@ -123,7 +123,7 @@ final class VRMSpringBone {
             if joints.indices.contains(index + 1) {
                 localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(joints[index + 1].utx.position)
             } else if let firstChild = joint.childNodes.first {
-                localChildPosition = firstChild.utx.localPosition * firstChild.utx.lossyScale
+                localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(firstChild.utx.position)
             } else if let parent = joint.parent {
                 let delta = joint.utx.position - parent.utx.position
                 let direction = delta.length_squared > Float.ulpOfOne ? delta.normalized : SIMD3<Float>(0, -1, 0)
@@ -146,13 +146,8 @@ final class VRMSpringBone {
             self.verlet.append(logic)
         } else {
             let firstChild = parent.childNodes.first!
-            let localPosition = firstChild.utx.localPosition
-            let scale = firstChild.utx.lossyScale
-            let logic = VRMSpringBoneLogic(center: center, node: parent, localChildPosition: SIMD3<Float>(
-                localPosition.x * scale.x,
-                localPosition.y * scale.y,
-                localPosition.z * scale.z
-            ))
+            let localChildPosition = parent.utx.worldToLocalMatrix.multiplyPoint(firstChild.utx.position)
+            let logic = VRMSpringBoneLogic(center: center, node: parent, localChildPosition: localChildPosition)
             self.verlet.append(logic)
         }
 

--- a/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMSpringBone.swift
@@ -126,7 +126,8 @@ final class VRMSpringBone {
                 localChildPosition = firstChild.utx.localPosition * firstChild.utx.lossyScale
             } else if let parent = joint.parent {
                 let delta = joint.utx.position - parent.utx.position
-                let childPosition = joint.utx.position + delta.normalized * 0.07
+                let direction = delta.length_squared > Float.ulpOfOne ? delta.normalized : SIMD3<Float>(0, -1, 0)
+                let childPosition = joint.utx.position + direction * 0.07
                 localChildPosition = joint.utx.worldToLocalMatrix.multiplyPoint(childPosition)
             } else {
                 continue
@@ -139,7 +140,8 @@ final class VRMSpringBone {
     private func setupRecursive(_ center: SCNNode?, _ parent: SCNNode) {
         if parent.utx.childCount == 0 {
             let delta = parent.utx.position - parent.parent!.utx.position
-            let childPosition = parent.utx.position + delta.normalized * 0.07
+            let direction = delta.length_squared > Float.ulpOfOne ? delta.normalized : SIMD3<Float>(0, -1, 0)
+            let childPosition = parent.utx.position + direction * 0.07
             let logic = VRMSpringBoneLogic(center: center, node: parent, localChildPosition: parent.utx.worldToLocalMatrix.multiplyPoint(childPosition))
             self.verlet.append(logic)
         } else {

--- a/Sources/VRMSceneKit/CustomType/VRMSpringBoneColliderGroup.swift
+++ b/Sources/VRMSceneKit/CustomType/VRMSpringBoneColliderGroup.swift
@@ -4,22 +4,66 @@ import SceneKit
 
 @available(*, deprecated, message: "Deprecated. Use VRMRealityKit instead.")
 final class VRMSpringBoneColliderGroup {
-    let node: SCNNode
-    let colliders: [SphereCollider]
+    let colliders: [Collider]
     
     init(colliderGroup: VRM0.SecondaryAnimation.ColliderGroup, loader: VRMSceneLoader) throws {
-        self.node = try loader.node(withNodeIndex: colliderGroup.node)
-        self.colliders = colliderGroup.colliders.map(SphereCollider.init)
+        let node = try loader.node(withNodeIndex: colliderGroup.node)
+        self.colliders = colliderGroup.colliders.map { Collider(node: node, collider: $0) }
+    }
+
+    init(colliderGroup: VRM1.SpringBone.ColliderGroup,
+         springBone: VRM1.SpringBone,
+         loader: VRMSceneLoader) throws {
+        let sourceColliders = springBone.colliders ?? []
+        self.colliders = try colliderGroup.colliders.compactMap { colliderIndex in
+            guard sourceColliders.indices.contains(colliderIndex) else { return nil }
+            return try Collider(collider: sourceColliders[colliderIndex], loader: loader)
+        }
     }
     
     @available(*, deprecated, message: "Deprecated. Use VRMRealityKit instead.")
-    final class SphereCollider {
+    final class Collider {
+        let node: SCNNode
         let offset: SIMD3<Float>
+        let tail: SIMD3<Float>?
         let radius: Float
+
+        var worldCollider: VRMSpringBone.Collider {
+            VRMSpringBone.Collider(head: node.utx.transformPoint(offset),
+                                   tail: tail.map(node.utx.transformPoint),
+                                   radius: radius)
+        }
         
-        init(collider: VRM0.SecondaryAnimation.ColliderGroup.Collider) {
+        init(node: SCNNode, collider: VRM0.SecondaryAnimation.ColliderGroup.Collider) {
+            self.node = node
             self.offset = collider.offset.simd
+            self.tail = nil
             self.radius = Float(collider.radius)
         }
+
+        init(collider: VRM1.SpringBone.Collider, loader: VRMSceneLoader) throws {
+            self.node = try loader.node(withNodeIndex: collider.node)
+            if let sphere = collider.shape.sphere {
+                self.offset = SIMD3<Float>(sphere.offset, defaultValue: .zero)
+                self.tail = nil
+                self.radius = Float(sphere.radius)
+            } else if let capsule = collider.shape.capsule {
+                self.offset = SIMD3<Float>(capsule.offset, defaultValue: .zero)
+                self.tail = SIMD3<Float>(capsule.tail, defaultValue: .zero)
+                self.radius = Float(capsule.radius)
+            } else {
+                self.offset = .zero
+                self.tail = nil
+                self.radius = 0
+            }
+        }
+    }
+}
+
+private extension SIMD3 where Scalar == Float {
+    init(_ values: [Double], defaultValue: SIMD3<Float>) {
+        self.init(Float(values[safe: 0] ?? Double(defaultValue.x)),
+                  Float(values[safe: 1] ?? Double(defaultValue.y)),
+                  Float(values[safe: 2] ?? Double(defaultValue.z)))
     }
 }

--- a/Sources/VRMSceneKit/GLTF2SCN/GLTF2SCN.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/GLTF2SCN.swift
@@ -89,3 +89,12 @@ extension GLTF.Color4 {
         return .init(red: CGFloat(r), green: CGFloat(g), blue: CGFloat(b), alpha: CGFloat(a))
     }
 }
+
+extension SKColor {
+    convenience init(color3 values: [Double], alpha: CGFloat) {
+        self.init(red: CGFloat(values[safe: 0] ?? 0),
+                  green: CGFloat(values[safe: 1] ?? 0),
+                  blue: CGFloat(values[safe: 2] ?? 0),
+                  alpha: alpha)
+    }
+}

--- a/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
@@ -7,15 +7,17 @@ extension SCNMaterial {
     convenience init(material: GLTF.Material, loader: VRMSceneLoader) throws {
         self.init()
         name = material.name
-//        lightingModel = .physicallyBased
-        lightingModel = .constant // FIXME:
+        let mtoon = material.extensions?.materialsMToon
+        let isMToon = mtoon != nil
+        let isUnlit = material.extensions?.materialsUnlit != nil
+        lightingModel = (isMToon || isUnlit) ? .constant : .physicallyBased
         isDoubleSided = material.doubleSided
-        isLitPerPixel = false
-        writesToDepthBuffer = material.alphaMode != .BLEND
+        isLitPerPixel = !(isMToon || isUnlit)
+        writesToDepthBuffer = mtoon?.transparentWithZWrite == true || material.alphaMode != .BLEND
 
         var shader: VRM0.MaterialProperty.Shader?
 
-        if let name = name, let property = loader.vrm.materialPropertyNameMap[name] {
+        if let name = name, let property = loader.vrm0MaterialProperty(named: name) {
             shader = property.vrmShader
             // FIXME/TODO: https://dwango.github.io/vrm/vrm_spec/#vrm%E3%81%8C%E6%8F%90%E4%BE%9B%E3%81%99%E3%82%8B%E3%82%B7%E3%82%A7%E3%83%BC%E3%83%80%E3%83%BC
             if shader == .unlitTransparent {
@@ -35,7 +37,7 @@ extension SCNMaterial {
 
             if let baseTexture = pbr.baseColorTexture {
                 try diffuse.setTextureInfo(baseTexture, loader: loader)
-                if shader == .mToon {
+                if shader == .mToon || isMToon {
                     multiply.contents = pbr.baseColorFactor.createSKColor()
                 }
             } else {
@@ -67,6 +69,43 @@ extension SCNMaterial {
 
         if let emissiveTexture = material.emissiveTexture {
             try emission.setTextureInfo(emissiveTexture, loader: loader)
+        }
+
+        if let mtoon {
+            applyMToon(mtoon, material: material, loader: loader)
+        }
+    }
+
+    private func applyMToon(_ mtoon: GLTF.Material.MaterialExtensions.MaterialsMToon,
+                            material: GLTF.Material,
+                            loader: VRMSceneLoader) {
+        if let shadeColor = mtoon.shadeColorFactor {
+            multiply.contents = SKColor(color3: shadeColor, alpha: 1.0)
+        }
+        if let shadeTexture = mtoon.shadeMultiplyTexture {
+            try? multiply.setMToonTextureInfo(shadeTexture, loader: loader)
+        }
+        if let matcapTexture = mtoon.matcapTexture {
+            try? reflective.setMToonTextureInfo(matcapTexture, loader: loader)
+        }
+        if let rimColor = mtoon.parametricRimColorFactor {
+            selfIllumination.contents = SKColor(color3: rimColor, alpha: 1.0)
+            selfIllumination.intensity = CGFloat(mtoon.parametricRimLiftFactor ?? 0)
+        }
+        if let rimTexture = mtoon.rimMultiplyTexture {
+            try? selfIllumination.setMToonTextureInfo(rimTexture, loader: loader)
+        }
+        if let outlineColor = mtoon.outlineColorFactor {
+            transparent.contents = SKColor(color3: outlineColor, alpha: 1.0)
+        }
+        if let uvMask = mtoon.uvAnimationMaskTexture {
+            try? ambient.setMToonTextureInfo(uvMask, loader: loader)
+        }
+        if material.alphaMode == .BLEND || mtoon.transparentWithZWrite == true {
+            blendMode = .alpha
+        }
+        if material.alphaMode == .MASK {
+            transparencyMode = .aOne
         }
     }
 

--- a/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNMaterial+GLTF.swift
@@ -10,12 +10,16 @@ extension SCNMaterial {
         let mtoon = material.extensions?.materialsMToon
         let isMToon = mtoon != nil
         let isUnlit = material.extensions?.materialsUnlit != nil
-        lightingModel = (isMToon || isUnlit) ? .constant : .physicallyBased
-        isDoubleSided = material.doubleSided
-        isLitPerPixel = !(isMToon || isUnlit)
-        writesToDepthBuffer = mtoon?.transparentWithZWrite == true || material.alphaMode != .BLEND
+        let isVRM0: Bool
+        switch loader.vrm {
+        case .v0:
+            isVRM0 = true
+        case .v1:
+            isVRM0 = false
+        }
 
         var shader: VRM0.MaterialProperty.Shader?
+        writesToDepthBuffer = mtoon?.transparentWithZWrite == true || material.alphaMode != .BLEND
 
         if let name = name, let property = loader.vrm0MaterialProperty(named: name) {
             shader = property.vrmShader
@@ -31,6 +35,11 @@ extension SCNMaterial {
         } else {
             blendMode = blendMode(of: material.alphaMode)
         }
+
+        let usesConstantLighting = isVRM0 || shader == .mToon || shader == .unlitTransparent || isMToon || isUnlit
+        lightingModel = usesConstantLighting ? .constant : .physicallyBased
+        isDoubleSided = material.doubleSided
+        isLitPerPixel = !usesConstantLighting
 
         if let pbr = material.pbrMetallicRoughness {
             // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#metallic-roughness-material

--- a/Sources/VRMSceneKit/GLTF2SCN/SCNMaterialProperty+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNMaterialProperty+GLTF.swift
@@ -30,6 +30,20 @@ extension SCNMaterialProperty {
         mappingChannel = textureInfo.texCoord
     }
 
+    func setMToonTextureInfo(_ textureInfo: GLTF.Material.MaterialExtensions.MaterialsMToon.MaterialsMToonTextureInfo,
+                             loader: VRMSceneLoader) throws {
+        let texture = try loader.texture(withTextureIndex: textureInfo.index)
+        contents = texture.contents
+        magnificationFilter = texture.magnificationFilter
+        minificationFilter = texture.minificationFilter
+        mipFilter = texture.mipFilter
+        wrapS = texture.wrapS
+        wrapT = texture.wrapT
+        intensity = texture.intensity
+
+        mappingChannel = textureInfo.texCoord ?? 0
+    }
+
     private func filterMode(of filter: GLTF.Sampler.MagFilter) -> SCNFilterMode {
         switch filter {
         case .NEAREST: return .nearest

--- a/Sources/VRMSceneKit/GLTF2SCN/SCNNode+GLTF.swift
+++ b/Sources/VRMSceneKit/GLTF2SCN/SCNNode+GLTF.swift
@@ -73,11 +73,10 @@ extension SCNNode {
                 node.geometry = geometry
 
                 // FIXME/TODO:
-                if let name = geometry.materials[0].name,
-                    let property = loader.vrm.materialPropertyNameMap[name],
-                    property.renderQueue != -1 {
+                if let renderQueue = try loader.renderQueue(forMaterialNamed: geometry.materials[0].name),
+                   renderQueue != -1 {
                     let lastRenderingOrder = childNodes.last?.renderingOrder ?? 0
-                    node.renderingOrder = lastRenderingOrder == 0 ? property.renderQueue : property.renderQueue + 1
+                    node.renderingOrder = lastRenderingOrder == 0 ? renderQueue : renderQueue + 1
                 }
             }
 

--- a/Sources/VRMSceneKit/VRMSceneLoader.swift
+++ b/Sources/VRMSceneKit/VRMSceneLoader.swift
@@ -48,11 +48,23 @@ open class VRMSceneLoader {
             guard let textureIndex = vrm0.meta.texture, textureIndex >= 0 else {
                 throw VRMError.thumbnailNotFound
             }
-            let texture = try gltf.load(\.textures)[textureIndex]
+            let textures = try gltf.load(\.textures)
+            guard textures.indices.contains(textureIndex) else {
+                throw VRMError.thumbnailNotFound
+            }
+            let texture = textures[textureIndex]
+            let images = try gltf.load(\.images)
+            guard images.indices.contains(texture.source) else {
+                throw VRMError.thumbnailNotFound
+            }
             if let cache = try sceneData.load(\.images, index: texture.source) { return cache }
             return try image(withImageIndex: texture.source)
         case .v1(let vrm1):
             guard let imageIndex = vrm1.meta.thumbnailImage, imageIndex >= 0 else {
+                throw VRMError.thumbnailNotFound
+            }
+            let images = try gltf.load(\.images)
+            guard images.indices.contains(imageIndex) else {
                 throw VRMError.thumbnailNotFound
             }
             if let cache = try sceneData.load(\.images, index: imageIndex) { return cache }

--- a/Sources/VRMSceneKit/VRMSceneLoader.swift
+++ b/Sources/VRMSceneKit/VRMSceneLoader.swift
@@ -32,7 +32,9 @@ open class VRMSceneLoader {
             vrmNode.addChildNode(try self.node(withNodeIndex: node))
         }
         vrmNode.setUpHumanoid(nodes: sceneData.nodes)
-        vrmNode.setUpBlendShapes(meshes: sceneData.meshes)
+        try vrmNode.setUpBlendShapes(nodes: sceneData.nodes, meshes: sceneData.meshes, loader: self)
+        vrmNode.setUpFirstPerson(nodes: sceneData.nodes, meshes: sceneData.meshes)
+        try vrmNode.setUpNodeConstraints(gltfNodes: try gltf.load(\.nodes), loader: self)
         try vrmNode.setUpSpringBones(loader: self)
 
         let scnScene = VRMScene(node: vrmNode)
@@ -41,11 +43,21 @@ open class VRMSceneLoader {
     }
 
     public func loadThumbnail() throws -> VRMImage {
-        guard let textureIndex = vrm.meta.texture, textureIndex >= 0 else {
-            throw VRMError.thumbnailNotFound
+        switch vrm {
+        case .v0(let vrm0):
+            guard let textureIndex = vrm0.meta.texture, textureIndex >= 0 else {
+                throw VRMError.thumbnailNotFound
+            }
+            let texture = try gltf.load(\.textures)[textureIndex]
+            if let cache = try sceneData.load(\.images, index: texture.source) { return cache }
+            return try image(withImageIndex: texture.source)
+        case .v1(let vrm1):
+            guard let imageIndex = vrm1.meta.thumbnailImage, imageIndex >= 0 else {
+                throw VRMError.thumbnailNotFound
+            }
+            if let cache = try sceneData.load(\.images, index: imageIndex) { return cache }
+            return try image(withImageIndex: imageIndex)
         }
-        if let cache = try sceneData.load(\.images, index: textureIndex) { return cache }
-        return try image(withImageIndex: textureIndex)
     }
 
     func node(withNodeIndex index: Int) throws -> SCNNode {
@@ -126,6 +138,33 @@ open class VRMSceneLoader {
         let material = try SCNMaterial(material: gltfMaterial, loader: self)
         sceneData.materials[index] = material
         return material
+    }
+
+    func vrm0MaterialProperty(named name: String) -> VRM0.MaterialProperty? {
+        guard case .v0(let vrm0) = vrm else { return nil }
+        return vrm0.materialPropertyNameMap[name]
+    }
+
+    func renderQueue(forMaterialNamed name: String?) throws -> Int? {
+        guard let name else { return nil }
+        switch vrm {
+        case .v0(let vrm0):
+            return vrm0.materialPropertyNameMap[name]?.renderQueue
+        case .v1:
+            guard let material = try gltf.load(\.materials).first(where: { $0.name == name }) else {
+                return nil
+            }
+            let baseQueue: Int
+            switch material.alphaMode {
+            case .OPAQUE:
+                baseQueue = 2000
+            case .MASK:
+                baseQueue = 2450
+            case .BLEND:
+                baseQueue = material.extensions?.materialsMToon?.transparentWithZWrite == true ? 2501 : 3000
+            }
+            return baseQueue + (material.extensions?.materialsMToon?.renderQueueOffsetNumber ?? 0)
+        }
     }
 
     func texture(withTextureIndex index: Int) throws -> SCNMaterialProperty {

--- a/Tests/VRMSceneKitTests/VRM1SceneKitTests.swift
+++ b/Tests/VRMSceneKitTests/VRM1SceneKitTests.swift
@@ -1,6 +1,7 @@
 import VRMKit
 @testable import VRMSceneKit
 import SceneKit
+import simd
 import Testing
 
 @Suite
@@ -41,5 +42,70 @@ struct VRM1SceneLoaderTests {
         let result = try vrmLoader.bufferView(withBufferViewIndex: 0)
         #expect(result.stride == nil)
         #expect(result.bufferView.count == 93840)
+    }
+
+    @Test
+    func testVRM1NativeExpressionBindingsUseNodes() throws {
+        let vrmLoader = try vrmLoader()
+        let scene = try vrmLoader.loadScene()
+        let vrmNode = scene.vrmNode
+
+        #expect(vrmNode.blendShapeClips.count == 18)
+        let happyBinding = try #require(vrmNode.blendShapeClips[.preset(.happy)]?.values.first)
+        #expect(happyBinding.mesh === (try vrmLoader.node(withNodeIndex: 2)))
+        #expect(vrmNode.blendShapeClips[.preset(.aa)]?.values.first?.index == 25)
+
+        vrmNode.setBlendShape(value: 0.42, for: .preset(.aa))
+        #expect(abs(vrmNode.blendShape(for: .preset(.aa)) - 0.42) < 0.001)
+        #expect(abs(vrmNode.blendShape(for: .preset(.a)) - 0.42) < 0.001)
+    }
+
+    @Test
+    func testVRM1FirstPersonAnnotationsUseNodes() throws {
+        let vrmLoader = try vrmLoader()
+        let scene = try vrmLoader.loadScene()
+        let annotatedNode = try vrmLoader.node(withNodeIndex: 0)
+
+        #expect(annotatedNode.isHidden == false)
+        scene.vrmNode.setFirstPersonRenderMode(.firstPerson)
+        #expect(annotatedNode.isHidden == true)
+        scene.vrmNode.setFirstPersonRenderMode(.thirdPerson)
+        #expect(annotatedNode.isHidden == false)
+    }
+
+    @Test
+    func testVRM1MToonMaterialIsLoadedFromExtension() throws {
+        let vrmLoader = try vrmLoader()
+        let material = try vrmLoader.material(withMaterialIndex: 0)
+        let gltfMaterial = try #require(vrmLoader.vrm.gltf.jsonData.materials?[0])
+
+        #expect(material.name == gltfMaterial.name)
+        #expect(material.lightingModel == .constant)
+        #expect(material.isLitPerPixel == false)
+        #expect(material.writesToDepthBuffer == true)
+    }
+
+    @Test
+    func testVRM1NodeConstraintRotationIsApplied() throws {
+        let vrmLoader = try vrmLoader()
+        let scene = try vrmLoader.loadScene()
+        let target = try vrmLoader.node(withNodeIndex: 14)
+        let source = try vrmLoader.node(withNodeIndex: 82)
+
+        let targetRest = target.simdOrientation
+        let sourceRest = source.simdOrientation
+        let sourceDelta = simd_quatf(angle: 0.35, axis: simd_normalize(SIMD3<Float>(0.2, 0.9, 0.3)))
+        source.simdOrientation = sourceRest * sourceDelta
+
+        scene.vrmNode.update(at: 0)
+
+        let expected = targetRest * (simd_inverse(sourceRest) * source.simdOrientation)
+        #expect(target.simdOrientation.isApproximatelyEqual(to: expected))
+    }
+}
+
+private extension simd_quatf {
+    func isApproximatelyEqual(to other: simd_quatf, tolerance: Float = 0.0001) -> Bool {
+        abs(simd_dot(vector, other.vector)) > 1.0 - tolerance
     }
 }

--- a/Tests/VRMSceneKitTests/VRMSceneKitTests.swift
+++ b/Tests/VRMSceneKitTests/VRMSceneKitTests.swift
@@ -43,10 +43,26 @@ class VRMSceneKitTests: XCTestCase {
         XCTAssertEqual(round(node.blendShape(for: .preset(.joy)) * 100), 85)
     }
 
+    func testVRM0MaterialsKeepConstantLighting() {
+        let loader = loadVRMLoader()
+        let materialCount = loader.vrm.gltf.jsonData.materials?.count ?? 0
+        XCTAssertGreaterThan(materialCount, 0)
+
+        for index in 0..<materialCount {
+            let material = try! loader.material(withMaterialIndex: index)
+            XCTAssertEqual(material.lightingModel, .constant, "Material \(index): \(material.name ?? "")")
+            XCTAssertFalse(material.isLitPerPixel, "Material \(index): \(material.name ?? "")")
+        }
+    }
+
     func loadVRM() -> VRMNode {
+        let loader = loadVRMLoader()
+        return try! loader.loadScene().vrmNode
+    }
+
+    func loadVRMLoader() -> VRMSceneLoader {
         let url = Bundle.module.url(forResource: "AliciaSolid", withExtension: "vrm")!
         let data = try! Data(contentsOf: url)
-        let loader = try! VRMSceneLoader(withData: data)
-        return try! loader.loadScene().vrmNode
+        return try! VRMSceneLoader(withData: data)
     }
 }


### PR DESCRIPTION
## Summary

Closes #27

- Add native VRM 1.0 rendering support for both SceneKit and RealityKit paths.
- Stop relying on VRM1 -> VRM0 migration data for runtime rendering features where VRM1 has different binding semantics.
- Wire VRM1-specific humanoid, expressions, first-person annotations, spring bones, node constraints, thumbnails, and MToon material handling.

## Details

- Add VRM1 expression runtime clips, including VRM1 preset names and VRM0-compatible aliases.
- Resolve VRM1 morph target binds by `node` index instead of migrated mesh indices.
- Apply VRM1 material color binds, and SceneKit texture transform binds.
- Load VRM1 MToon / unlit materials directly from glTF extensions, including render queue and `transparentWithZWrite` behavior.
- Add native VRM1 SpringBone support with collider groups, capsule colliders, and per-joint settings.
- Add runtime support for `VRMC_node_constraint` roll / aim / rotation constraints with dependency ordering.
- Fix VRM1 thumbnail loading to use `meta.thumbnailImage` as an image index.
- Update humanoid setup for VRM1 bone definitions.

## Validation

- `swift build --scratch-path /private/tmp/VRMKit-build`
- `swift test --scratch-path /private/tmp/VRMKit-build`
- `git diff --check`
- Manually confirmed that a VRM 1.0 model renders correctly in the sample app.