### PR TITLE
Custom shader support

### DIFF
--- a/Example/Example/RealityKitViewController.swift
+++ b/Example/Example/RealityKitViewController.swift
@@ -118,7 +118,8 @@ final class RealityKitViewController: UIViewController, UIGestureRecognizerDeleg
         loadedEntity = nil
 
         do {
-            let loader = try VRMEntityLoader(named: model.rawValue, isMToonEnabled: isMToonEnabled)
+            let loader = try VRMEntityLoader(named: model.rawValue,
+                                             shaders: isMToonEnabled ? GLTFEntityLoader.defaultShaders : [])
             let vrmEntity = try loader.loadEntity()
             vrmEntity.setMToonLightDirection(RealityKitExampleLighting.direction)
 

--- a/Example/MacExample/ContentView.swift
+++ b/Example/MacExample/ContentView.swift
@@ -191,7 +191,8 @@ final class RealityKitContentViewModel {
         do {
             errorMessage = nil
 
-            let loader = try VRMEntityLoader(named: model.rawValue, isMToonEnabled: isMToonEnabled)
+            let loader = try VRMEntityLoader(named: model.rawValue,
+                                             shaders: isMToonEnabled ? GLTFEntityLoader.defaultShaders : [])
             let nextVRMEntity = try loader.loadEntity()
 
             nextVRMEntity.transform.translation = SIMD3<Float>(0, -1, 0)

--- a/README.md
+++ b/README.md
@@ -27,26 +27,20 @@ For "VRM", please refer to [this page](https://dwango.github.io/en/vrm/).
 - [x] Face morphing (blend shape)
 - [x] Bone animation (skin / joint)
 - [x] Physics (spring bone)
+- [x] MToon rendering and custom material shaders
+- [x] Render plain glTF / GLB with animations
 
 # Requirements
 
 - Swift 6.0+
-- iOS 15.0+
-- macOS 12.0+
-- visionOS 2.0+
-- watchOS 8.0+ (Experimental)
-
-VRMRealityKit requires iOS 18.0+ / macOS 15.0+ / visionOS 2.0+.
+- iOS 15.0+ / macOS 12.0+ / visionOS 2.0+ / watchOS 8.0+ (experimental)
+- VRMRealityKit: iOS 18.0+ / macOS 15.0+ / visionOS 2.0+
 
 # Installation
 
 ## Swift Package Manager
 
 You can install this package with Swift Package Manager.
-
-## Carthage & CocoaPods (Deprecated)
-
-If you want to use these package managers, please use https://github.com/tattn/VRMKit/releases/tag/0.4.2
 
 # Usage
 
@@ -55,9 +49,10 @@ If you want to use these package managers, please use https://github.com/tattn/V
 ```swift
 import VRMKit
 
-let vrm = try VRMLoader().load(named: "model.vrm")
-// let vrm = try VRMLoader().load(withUrl: URL(string: "/path/to/model.vrm")!)
-// let vrm = try VRMLoader().load(withData: data)
+let loader = VRMLoader()
+let vrm = try loader.load(named: "model.vrm")
+// let vrm = try loader.load(withUrl: URL(string: "/path/to/model.vrm")!)
+// let vrm = try loader.load(withData: data)
 
 // VRM meta data
 vrm.meta.title
@@ -65,96 +60,49 @@ vrm.meta.author
 
 // model data
 vrm.gltf.jsonData.nodes[0].name
+
+// thumbnail
+try loader.loadThumbnail(from: vrm)
 ```
 
 ## Render VRM
 
 ```swift
 import RealityKit
-import VRMKit
-import VRMRealityKit
-
-let loader = try VRMEntityLoader(named: "model.vrm")
-let vrmEntity = try loader.loadEntity()
-
-let arView = ARView(frame: .zero, cameraMode: .nonAR, automaticallyConfigureSession: false)
-let anchor = AnchorEntity(world: .zero)
-anchor.addChild(vrmEntity)
-arView.scene.addAnchor(anchor)
-```
-
-`VRMEntity` is an `Entity`. Once it is in a scene, skinning, constraints and spring bones are updated every frame automatically.
-
-### Render VRM (SwiftUI)
-
-```swift
-import RealityKit
 import SwiftUI
-import VRMKit
 import VRMRealityKit
 
 struct ContentView: View {
     var body: some View {
         RealityView { content in
-            guard let loader = try? VRMEntityLoader(named: "model.vrm"),
-                  let vrmEntity = try? loader.loadEntity() else { return }
-            content.add(vrmEntity)
+            guard let entity = try? VRMEntityLoader(named: "model.vrm").loadEntity() else { return }
+            content.add(entity)
         }
     }
 }
 ```
 
-<details>
-<summary>Render VRM (SceneKit) — Deprecated</summary>
+`VRMEntity` is an `Entity`, so it drops into any RealityKit scene, `ARView` included. Once it is in a scene, skinning, constraints and spring bones update every frame automatically; set `isAutomaticUpdateEnabled = false` and call `update(deltaTime:)` to drive the timing yourself. Animation code that must run in a fixed order relative to that update belongs in a `System` declared with `SystemDependency.before(VRMUpdateSystem.self)`.
 
-> Note: VRMSceneKit is deprecated. Use VRMRealityKit instead.
+> VRMSceneKit, the SceneKit renderer, is deprecated. Use VRMRealityKit instead.
 
-```swift
-import VRMKit
-import VRMSceneKit
-
-@IBOutlet weak var sceneView: SCNView!
-
-let loader = try VRMSceneLoader(named: "model.vrm")
-let scene: VRMScene = try loader.loadScene()
-let node: VRMNode = scene.vrmNode
-
-sceneView.scene = scene
-```
-
-</details>
-
-### Blend shapes / expressions
-
-VRM 0.x uses blend shapes:
+## Expressions / blend shapes
 
 <img src="https://github.com/tattn/VRMKit/raw/main/.github/alicia_joy.png" width="100px" alt="joy" />
-
-```swift
-vrmEntity.setBlendShape(value: 1.0, for: .preset(.joy))
-```
-
 <img src="https://github.com/tattn/VRMKit/raw/main/.github/alicia_angry.png" width="100px" alt="angry" />
-
-```swift
-vrmEntity.setBlendShape(value: 1.0, for: .preset(.angry))
-```
-
 <img src="https://github.com/tattn/VRMKit/raw/main/.github/alicia_><.png" width="100px" alt="><" />
 
 ```swift
+// VRM 1.0
+vrmEntity.setExpression(value: 1.0, for: .preset(.happy))
+vrmEntity.setExpression(value: 1.0, for: .custom("customExpressionName"))
+
+// VRM 0.x
+vrmEntity.setBlendShape(value: 1.0, for: .preset(.joy))
 vrmEntity.setBlendShape(value: 1.0, for: .custom("><"))
 ```
 
-VRM 1.0 uses expressions:
-
-```swift
-vrmEntity.setExpression(value: 1.0, for: .preset(.happy))
-vrmEntity.setExpression(value: 1.0, for: .preset(.aa))
-vrmEntity.setExpression(value: 1.0, for: .custom("customExpressionName"))
-```
-
-### Bone animation
+## Bone animation
 
 <img src="https://github.com/tattn/VRMKit/raw/main/.github/alicia_humanoid.png" width="200px" alt="Humanoid" />
 
@@ -163,17 +111,9 @@ let neckRotation = simd_quatf(angle: 20 * .pi / 180, axis: SIMD3<Float>(0, 0, 1)
 vrmEntity.humanoid.node(for: .neck)?.transform.rotation *= neckRotation
 ```
 
-### Read the thumbnail image
-
-```swift
-let loader = VRMLoader()
-let vrm = try loader.load(named: "model.vrm")
-let image = try loader.loadThumbnail(from: vrm)
-```
-
 ## MToon rendering
 
-VRMRealityKit renders MToon materials by default on iOS and macOS. visionOS falls back to Unlit / PBR materials because RealityKit's `CustomMaterial` is unavailable there.
+MToon materials render by default on iOS and macOS. visionOS falls back to Unlit / PBR materials, because RealityKit's `CustomMaterial` is unavailable there.
 
 ```swift
 vrmEntity.setMToonLightDirection(SIMD3<Float>(0, 0, -1))
@@ -181,53 +121,43 @@ vrmEntity.setMToonLightColor(SIMD3<Float>(1, 1, 1))
 vrmEntity.setMToonAmbientColor(SIMD3<Float>(0.1, 0.1, 0.1))
 ```
 
-<details>
-<summary>Loader options and limitations</summary>
+Both loaders take a material shader chain: each shader is asked in order, and materials no shader claims render through the built-in Unlit / PBR path.
 
 ```swift
-let loader = try VRMEntityLoader(
-    named: "model.vrm",
-    isMToonEnabled: true,  // false: disable MToon and use the legacy Unlit / PBR conversion
-    isOutlineEnabled: true // false: skip MToon outline entities
-)
+// The default chain is [MToonShader()]: MToon with outlines.
+let noOutlines = try VRMEntityLoader(named: "model.vrm", shaders: [MToonShader(isOutlineEnabled: false)])
+let noMToon = try VRMEntityLoader(named: "model.vrm", shaders: [])
+
+// Toon-shade a plain glTF, or a VRM whose materials are not MToon.
+// Pass .convertAll(MToonConversionStyle(...)) to tune the conversion.
+let converted = try GLTFEntityLoader(withURL: url, shaders: [MToonShader(source: .convertAll)])
+
+// Your own shader joins the same chain.
+final class MyShader: GLTFMaterialShader {
+    func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+        // Return nil to pass the material on to the next shader / built-in path,
+        // or start from try context.standardMaterial() to adjust the standard result.
+        var material = UnlitMaterial()
+        if let texture = context.material.pbrMetallicRoughness?.baseColorTexture {
+            material.color = .init(texture: try context.materialTexture(withTextureIndex: texture.index))
+        }
+        return GLTFShadedMaterial(material: material)
+    }
+}
+
+let custom = try VRMEntityLoader(withData: data, shaders: [MyShader(), MToonShader()])
 ```
 
-Outlines can be skipped while keeping the MToon surface shader. On visionOS both options fall back automatically because the required RealityKit APIs are unavailable.
+`GLTFShadedMaterial` also carries extra render passes (MToon draws its outline as one) and a `makeAnimatableState` closure that lets VRM expressions animate a custom material. The `GLTFMaterialShader` documentation comments cover both, along with what a shader may assume about the mesh it draws.
 
-RealityKit constrains what the MToon renderer can express. Each case below logs a warning once per affected material.
+## Render glTF / GLB
 
-- `renderQueueOffsetNumber` is parsed but ignored, because RealityKit has no material-level draw-order hook. (`transparentWithZWrite` is supported through `CustomMaterial.writesDepth`, so a blended material can still write depth.)
-- Textures requesting a UV set other than `TEXCOORD_0` use `TEXCOORD_0`, because custom meshes expose only that one.
-- When UV-accessed texture slots specify different `KHR_texture_transform` values, the transform of the first UV-accessed slot — base color when the material has one — is applied to all of them, because `CustomMaterial` has a single material-level UV transform. Expression texture transform binds still update all UV-accessed textures together as required by VRMC_vrm.
-
-</details>
-
-<details>
-<summary>Frame updates</summary>
-
-`VRMUpdateSystem` (a RealityKit `System` registered on load) calls `VRMEntity.update(deltaTime:)` on every render frame. To control the timing yourself, opt out and call it manually:
-
-```swift
-vrmEntity.isAutomaticUpdateEnabled = false
-
-// Then, once per frame:
-vrmEntity.update(deltaTime: deltaTime)
-```
-
-To run your own animation code in a guaranteed order relative to the VRM update (e.g. posing joints that the same frame's skinning should reflect), put it in a custom `System` declared with `SystemDependency.before(VRMUpdateSystem.self)`.
-
-</details>
-
-<details>
-<summary>Render glTF / GLB</summary>
-
-VRMRealityKit can also render plain glTF assets (`.glb` and JSON `.gltf`, including external resources and data URIs).
+VRMRealityKit also renders plain glTF assets (`.glb` and JSON `.gltf`, including external resources and data URIs).
 
 ```swift
 let entity: GLTFEntity = try GLTFEntityLoader(withURL: url).loadEntity()
-content.add(entity)
 
-entity.animations          // [GLTFAnimation] — index, name, duration
+entity.animations          // [GLTFAnimation]: index, name, duration
 let controller = try entity.playAnimation(at: 0, loops: true)
 controller.speed = 2       // a negative speed plays backwards
 controller.seek(to: 0.5)
@@ -236,38 +166,30 @@ controller.stop()
 
 `loadEntity()` renders the asset's default scene, and throws when the glTF names none; pick one with `loadEntity(withSceneIndex:)`. A `clone(recursive:)` copy shares the loaded meshes and materials but not the animation bindings, so load the scene again for a second animatable instance.
 
-### RealityKit renderer limitations
+<details>
+<summary>Renderer limitations</summary>
 
-The renderer builds RealityKit meshes and materials, so a few parts of glTF have no place to go:
+RealityKit meshes and materials cannot express every part of glTF and MToon. Each case below logs a warning once per affected material.
 
 - Only triangle primitives are drawn; `POINTS` and `LINES` primitives are skipped.
-- `COLOR_0` vertex colors are ignored: the `MeshResource.Part` buffers this renderer builds carry no vertex-color channel.
-- One UV set per material: the first UV-accessed texture decides both the `TEXCOORD_n` set and the single `KHR_texture_transform` every texture of that material is sampled with. An asset that merely lists `KHR_texture_transform` in `extensionsUsed` renders through that approximation and logs it; one that lists it in `extensionsRequired` and gives a material's textures different transforms is rejected instead of drawn wrong.
+- `COLOR_0` vertex colors are ignored: the mesh buffers this renderer builds carry no vertex-color channel.
+- One UV set and one `KHR_texture_transform` per material: the first UV-accessed texture decides both for every texture of that material. A glTF load rejects a document that lists `KHR_texture_transform` in `extensionsRequired` and needs more than that, instead of drawing it wrong; a VRM load renders the approximation.
 - Tangents for a primitive without `TANGENT` are averaged from its UV gradients rather than generated with MikkTSpace, which the spec recommends, so a normal map baked against MikkTSpace can differ slightly along UV seams.
 - Blend shapes morph `POSITION` only, since RealityKit blend shapes have no `NORMAL` / `TANGENT` channel.
-- Skinning reads `JOINTS_0` / `WEIGHTS_0` only, so a vertex is driven by at most four joints; the further sets a glTF may carry (`JOINTS_1` and up) are ignored, which the spec allows and which can change the result of an animation.
+- Skinning reads `JOINTS_0` / `WEIGHTS_0` only, so a vertex is driven by at most four joints; the further sets a glTF may carry are ignored.
+- MToon's `renderQueueOffsetNumber` is parsed but ignored, because RealityKit has no material-level draw-order hook. (`transparentWithZWrite` is supported through `CustomMaterial.writesDepth`.)
 
 </details>
 
 # ToDo
 
-- [x] VRM 1.0 support
-  - [x] Decoding VRM 1.0 file
-  - [x] Render an avatar by RealityKit (as VRM 0.x)
-  - [x] Render an avatar by RealityKit (as VRM 1.x)
-- [x] VRM shaders support (MToon, RealityKit)
 - [ ] Improve rendering quality
 - [ ] Animation support (vrma)
 - [ ] VRM editing function
-- [x] glTF renderer / animation support (RealityKit)
 
 # Contributing
 
-1. Fork it!
-2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -am 'Add some feature'`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request :D
+Pull requests are welcome. Fork the repository, work on a feature branch, and open a PR :D
 
 ## Support this project
 
@@ -283,5 +205,5 @@ VRMKit is released under the MIT license. See LICENSE for details.
 
 Tatsuya Tanaka
 
-<a href="https://twitter.com/tattn_dev" target="_blank"><img alt="Twitter" src="https://img.shields.io/twitter/follow/tattn_dev.svg?style=social&label=Follow"></a>
+<a href="https://x.com/tattn_dev" target="_blank"><img alt="Twitter" src="https://img.shields.io/twitter/follow/tattn_dev.svg?style=social&label=Follow"></a>
 <a href="https://github.com/tattn" target="_blank"><img alt="GitHub" src="https://img.shields.io/github/followers/tattn.svg?style=social"></a>

--- a/Sources/VRMKit/Extensions/Accessor+Data.swift
+++ b/Sources/VRMKit/Extensions/Accessor+Data.swift
@@ -74,7 +74,7 @@ package extension GLTF.Accessor {
 private extension GLTF.Accessor {
     /// The element size, rejecting the matrix layouts glTF pads. MAT2 / MAT3
     /// columns are aligned to 4 bytes, so with small component types an element
-    /// is wider than its components — a layout no VRM asset uses, and one the
+    /// is wider than its components, a layout no VRM asset uses and one the
     /// readers above would mis-slice.
     func unpaddedVectorSize() throws -> Int {
         let (componentsPerVector, bytesPerComponent, vectorSize) = components()

--- a/Sources/VRMKit/Extensions/Data+GLTF.swift
+++ b/Sources/VRMKit/Extensions/Data+GLTF.swift
@@ -148,7 +148,7 @@ package extension URL {
     ///
     /// A `uri` is a URI reference, not a file path: its reserved characters are
     /// percent-encoded, so `My%20Buffer.bin` names a file with a space in it.
-    /// Only local files are read — a glTF must not fetch resources off the
+    /// Only local files are read: a glTF must not fetch resources off the
     /// network on the caller's behalf.
     init(gltfUri: String, relativeTo rootDirectory: URL?) throws {
         // A uri that is not a valid URI reference is taken as a literal path,

--- a/Sources/VRMKit/Extensions/PackedAccessor.swift
+++ b/Sources/VRMKit/Extensions/PackedAccessor.swift
@@ -87,8 +87,8 @@ package struct PackedAccessor {
 /// Accessors expanded once and reused, so the primitives, skins and animation
 /// samplers that share one accessor expand it a single time.
 ///
-/// A cache holds decoded geometry, so it belongs to whatever needs it — one
-/// scene load, one animation binding — and is dropped with it.
+/// A cache holds decoded geometry, so it belongs to whatever needs it (one
+/// scene load, one animation binding) and is dropped with it.
 package final class PackedAccessorCache {
     private let document: GLTFDocument
     private var packedAccessors: [Int: PackedAccessor] = [:]

--- a/Sources/VRMKit/GLTFDocument.swift
+++ b/Sources/VRMKit/GLTFDocument.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A parsed glTF asset together with the context needed to resolve its binary
-/// resources — the GLB BIN chunk, external files and data URIs — so that they
+/// resources (the GLB BIN chunk, external files and data URIs), so that they
 /// stay resolvable after loading, e.g. for lazily decoded animation accessors.
 public final class GLTFDocument {
     public let gltf: GLTF
@@ -13,7 +13,7 @@ public final class GLTFDocument {
     /// Decoded buffers, keyed by buffer index: resolving one re-reads an external
     /// file or base64-decodes a whole data URI.
     ///
-    /// Buffer *views* are deliberately not cached — they are copies out of these
+    /// Buffer *views* are deliberately not cached: they are copies out of these
     /// buffers, and keeping them would hold the file's bytes a second time.
     private var buffers: [Int: Data] = [:]
 

--- a/Sources/VRMKit/GLTFLoader.swift
+++ b/Sources/VRMKit/GLTFLoader.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Loads plain glTF assets — GLB containers and JSON `.gltf` files with
-/// external or data-URI resources — into a ``GLTFDocument``.
+/// Loads plain glTF assets into a ``GLTFDocument``: GLB containers, and JSON
+/// `.gltf` files with external or data-URI resources.
 public final class GLTFLoader {
     public init() {}
 

--- a/Sources/VRMKitRuntime/BlendShapeBindings.swift
+++ b/Sources/VRMKitRuntime/BlendShapeBindings.swift
@@ -96,7 +96,7 @@ package typealias ExpressionOverrideType = VRM1.Expressions.Expression.Expressio
 
 /// Accumulates every active expression's override of one group, following
 /// VRMC_vrm: `block` zeroes the group outright, while simultaneous `blend`
-/// overrides *add up* before being saturated — they do not compose
+/// overrides *add up* before being saturated, rather than composing
 /// multiplicatively.
 package struct ExpressionOverrideState {
     private var isBlocked = false

--- a/Sources/VRMKitRuntime/Extensions/AnyNumeric+.swift
+++ b/Sources/VRMKitRuntime/Extensions/AnyNumeric+.swift
@@ -21,7 +21,7 @@ package func numericFloatValue(_ value: Any) -> Float? {
 /// Coerces a loosely-typed JSON number into an `Int` index. Only exact,
 /// non-negative integers within `Int32` are accepted: glTF indices are small,
 /// and `Int(_:)` traps on values a fixed-width integer cannot represent. The
-/// number is read as a `Double` because `Float` rounds integers past 2^24 —
+/// number is read as a `Double` because `Float` rounds integers past 2^24, so
 /// `16_777_217` and `Int32.max` would both pass a `Float` test as some other
 /// value.
 package func numericIndexValue(_ value: Any) -> Int? {

--- a/Sources/VRMKitRuntime/MToonMaterialDescriptor.swift
+++ b/Sources/VRMKitRuntime/MToonMaterialDescriptor.swift
@@ -65,6 +65,31 @@ package struct MToonMaterialDescriptor {
 }
 
 package extension MToonMaterialDescriptor {
+    /// What MToon data a glTF material carries. A material authored against an
+    /// unimplemented spec version *is* MToon, so renderers must tell it from one
+    /// that carries no MToon data at all and is theirs to shade freely.
+    enum Resolution {
+        /// The material carries no MToon data.
+        case none
+        /// The material's MToon data, decoded.
+        case supported(MToonMaterialDescriptor)
+        /// The material declares `VRMC_materials_mtoon` with the given
+        /// `specVersion`, which ``supports(specVersion:)`` does not implement.
+        case unsupportedVersion(String)
+
+        /// Whether the material is MToon at all, readable or not.
+        package var isMToon: Bool {
+            if case .none = self { return false }
+            return true
+        }
+
+        /// The decoded MToon data, or nil when there is none to read.
+        package var descriptor: MToonMaterialDescriptor? {
+            guard case .supported(let descriptor) = self else { return nil }
+            return descriptor
+        }
+    }
+
     /// The `VRMC_materials_mtoon` spec versions this descriptor implements.
     /// Anything else falls back to Unlit / PBR rather than being read with 1.0
     /// semantics.
@@ -72,18 +97,81 @@ package extension MToonMaterialDescriptor {
         specVersion == "1.0" || specVersion == "1.0-beta"
     }
 
-    init?(material: GLTF.Material, materialProperty: VRM0.MaterialProperty?) {
+    /// The MToon data `material` carries, from the `VRMC_materials_mtoon`
+    /// extension or, for VRM 0.x, the Unity material property describing it.
+    static func resolve(material: GLTF.Material,
+                        materialProperty: VRM0.MaterialProperty?) -> Resolution {
         if let mtoon = material.extensions?.materialsMToon {
-            guard Self.supports(specVersion: mtoon.specVersion) else { return nil }
-            self.init(vrm1: mtoon, material: material)
-            return
+            guard supports(specVersion: mtoon.specVersion) else {
+                return .unsupportedVersion(mtoon.specVersion)
+            }
+            return .supported(MToonMaterialDescriptor(vrm1: mtoon, material: material))
         }
 
         guard let materialProperty,
               materialProperty.vrmShader == .mToon || materialProperty.shader.lowercased().contains("mtoon") else {
+            return .none
+        }
+        return .supported(VRM0MToonMigrator.migrate(property: materialProperty, material: material))
+    }
+
+    /// The decoded MToon data, or nil when there is none this descriptor can
+    /// read. ``resolve(material:materialProperty:)`` tells those two apart.
+    init?(material: GLTF.Material, materialProperty: VRM0.MaterialProperty?) {
+        guard let descriptor = Self.resolve(material: material,
+                                            materialProperty: materialProperty).descriptor else {
             return nil
         }
-        self = VRM0MToonMigrator.migrate(property: materialProperty, material: material)
+        self = descriptor
+    }
+}
+
+package extension MToonMaterialDescriptor {
+    /// MToon 1.0 spec defaults, used as fallbacks for omitted authored values
+    /// and synthesized standard materials.
+    enum SpecDefault {
+        package static let shadingShiftFactor: Float = 0
+        static let shadingShiftTextureScale: Float = 1
+        package static let shadingToonyFactor: Float = 0.9
+        static let giEqualizationFactor: Float = 0.9
+        static let matcapFactor = SIMD3<Float>(1, 1, 1)
+        static let parametricRimColorFactor = SIMD4<Float>(0, 0, 0, 1)
+        static let rimLightingMixFactor: Float = 1
+        static let parametricRimFresnelPowerFactor: Float = 5
+        static let parametricRimLiftFactor: Float = 0
+        package static let outlineWidthFactor: Float = 0
+        package static let outlineColorFactor = SIMD4<Float>(0, 0, 0, 1)
+        static let outlineLightingMixFactor: Float = 1
+        static let uvAnimationSpeedFactor: Float = 0
+        static let transparentWithZWrite = false
+        static let renderQueueOffsetNumber = 0
+    }
+
+    /// The fields every descriptor derives the same way from the standard glTF
+    /// material, whether the toon values are authored or synthesized.
+    struct StandardMaterialProperties {
+        let baseColorFactor: SIMD4<Float>
+        let emissiveFactor: SIMD3<Float>
+        let alphaMode: GLTF.Material.AlphaMode
+        let alphaCutoff: Float
+        let cullMode: CullMode
+        let normalScale: Float
+        let baseColorTexture: Texture?
+        let emissiveTexture: Texture?
+        let normalTexture: Texture?
+
+        init(_ material: GLTF.Material) {
+            let pbr = material.pbrMetallicRoughness
+            baseColorFactor = (pbr?.baseColorFactor).map(SIMD4<Float>.init) ?? SIMD4<Float>(1, 1, 1, 1)
+            emissiveFactor = SIMD3<Float>(material.emissiveFactor)
+            alphaMode = material.alphaMode
+            alphaCutoff = material.alphaCutoff
+            cullMode = material.doubleSided ? .none : .back
+            normalScale = Float(material.normalTexture?.scale ?? 1)
+            baseColorTexture = pbr?.baseColorTexture.map(Texture.init)
+            emissiveTexture = material.emissiveTexture.map(Texture.init)
+            normalTexture = material.normalTexture.map(Texture.init)
+        }
     }
 }
 
@@ -108,43 +196,46 @@ package extension MToonMaterialDescriptor {
 
 private extension MToonMaterialDescriptor {
     init(vrm1 mtoon: GLTF.Material.MaterialExtensions.MaterialsMToon, material: GLTF.Material) {
-        let pbr = material.pbrMetallicRoughness
-        let baseColor = (pbr?.baseColorFactor).map(SIMD4<Float>.init) ?? SIMD4<Float>(1, 1, 1, 1)
-        let shadeColor = SIMD4<Float>(mtoon.shadeColorFactor, default: SIMD4<Float>(0, 0, 0, 1))
-        let matcapFactor = SIMD3<Float>(mtoon.matcapFactor, default: SIMD3<Float>(1, 1, 1))
-        let rimColor = SIMD4<Float>(mtoon.parametricRimColorFactor, default: SIMD4<Float>(0, 0, 0, 1))
-        let outlineColor = SIMD4<Float>(mtoon.outlineColorFactor, default: SIMD4<Float>(0, 0, 0, 1))
+        let standard = StandardMaterialProperties(material)
 
-        self.baseColorFactor = baseColor
-        self.emissiveFactor = SIMD3<Float>(material.emissiveFactor)
-        self.shadeColorFactor = shadeColor
-        self.shadingShiftFactor = Float(mtoon.shadingShiftFactor ?? 0)
-        self.shadingShiftTextureScale = Float(mtoon.shadingShiftTexture?.scale ?? 1)
-        self.shadingToonyFactor = Float(mtoon.shadingToonyFactor ?? 0.9)
-        self.giEqualizationFactor = Float(mtoon.giEqualizationFactor ?? 0.9)
-        self.matcapFactor = matcapFactor
-        self.parametricRimColorFactor = rimColor
-        self.rimLightingMixFactor = Float(mtoon.rimLightingMixFactor ?? 1)
-        self.parametricRimFresnelPowerFactor = Float(mtoon.parametricRimFresnelPowerFactor ?? 5)
-        self.parametricRimLiftFactor = Float(mtoon.parametricRimLiftFactor ?? 0)
+        self.baseColorFactor = standard.baseColorFactor
+        self.emissiveFactor = standard.emissiveFactor
+        self.shadeColorFactor = SIMD4<Float>(mtoon.shadeColorFactor, default: SIMD4<Float>(0, 0, 0, 1))
+        self.shadingShiftFactor = mtoon.shadingShiftFactor.map(Float.init) ?? SpecDefault.shadingShiftFactor
+        self.shadingShiftTextureScale = (mtoon.shadingShiftTexture?.scale).map(Float.init)
+            ?? SpecDefault.shadingShiftTextureScale
+        self.shadingToonyFactor = mtoon.shadingToonyFactor.map(Float.init) ?? SpecDefault.shadingToonyFactor
+        self.giEqualizationFactor = mtoon.giEqualizationFactor.map(Float.init) ?? SpecDefault.giEqualizationFactor
+        self.matcapFactor = SIMD3<Float>(mtoon.matcapFactor, default: SpecDefault.matcapFactor)
+        self.parametricRimColorFactor = SIMD4<Float>(mtoon.parametricRimColorFactor,
+                                                     default: SpecDefault.parametricRimColorFactor)
+        self.rimLightingMixFactor = mtoon.rimLightingMixFactor.map(Float.init) ?? SpecDefault.rimLightingMixFactor
+        self.parametricRimFresnelPowerFactor = mtoon.parametricRimFresnelPowerFactor.map(Float.init)
+            ?? SpecDefault.parametricRimFresnelPowerFactor
+        self.parametricRimLiftFactor = mtoon.parametricRimLiftFactor.map(Float.init)
+            ?? SpecDefault.parametricRimLiftFactor
         self.outlineWidthMode = .init(vrm1: mtoon.outlineWidthMode)
-        self.outlineWidthFactor = Float(mtoon.outlineWidthFactor ?? 0)
-        self.outlineColorFactor = outlineColor
-        self.outlineLightingMixFactor = Float(mtoon.outlineLightingMixFactor ?? 1)
-        self.uvAnimationScrollXSpeedFactor = Float(mtoon.uvAnimationScrollXSpeedFactor ?? 0)
-        self.uvAnimationScrollYSpeedFactor = Float(mtoon.uvAnimationScrollYSpeedFactor ?? 0)
-        self.uvAnimationRotationSpeedFactor = Float(mtoon.uvAnimationRotationSpeedFactor ?? 0)
-        self.transparentWithZWrite = mtoon.transparentWithZWrite ?? false
-        self.renderQueueOffsetNumber = mtoon.renderQueueOffsetNumber ?? 0
-        self.alphaMode = material.alphaMode
-        self.alphaCutoff = material.alphaCutoff
-        self.cullMode = material.doubleSided ? .none : .back
-        self.normalScale = Float(material.normalTexture?.scale ?? 1)
-        self.baseColorTexture = pbr?.baseColorTexture.map(MToonMaterialDescriptor.Texture.init)
-        self.emissiveTexture = material.emissiveTexture.map(MToonMaterialDescriptor.Texture.init)
+        self.outlineWidthFactor = mtoon.outlineWidthFactor.map(Float.init) ?? SpecDefault.outlineWidthFactor
+        self.outlineColorFactor = SIMD4<Float>(mtoon.outlineColorFactor, default: SpecDefault.outlineColorFactor)
+        self.outlineLightingMixFactor = mtoon.outlineLightingMixFactor.map(Float.init)
+            ?? SpecDefault.outlineLightingMixFactor
+        self.uvAnimationScrollXSpeedFactor = mtoon.uvAnimationScrollXSpeedFactor.map(Float.init)
+            ?? SpecDefault.uvAnimationSpeedFactor
+        self.uvAnimationScrollYSpeedFactor = mtoon.uvAnimationScrollYSpeedFactor.map(Float.init)
+            ?? SpecDefault.uvAnimationSpeedFactor
+        self.uvAnimationRotationSpeedFactor = mtoon.uvAnimationRotationSpeedFactor.map(Float.init)
+            ?? SpecDefault.uvAnimationSpeedFactor
+        self.transparentWithZWrite = mtoon.transparentWithZWrite ?? SpecDefault.transparentWithZWrite
+        self.renderQueueOffsetNumber = mtoon.renderQueueOffsetNumber ?? SpecDefault.renderQueueOffsetNumber
+        self.alphaMode = standard.alphaMode
+        self.alphaCutoff = standard.alphaCutoff
+        self.cullMode = standard.cullMode
+        self.normalScale = standard.normalScale
+        self.baseColorTexture = standard.baseColorTexture
+        self.emissiveTexture = standard.emissiveTexture
         self.shadeMultiplyTexture = mtoon.shadeMultiplyTexture.map(MToonMaterialDescriptor.Texture.init)
         self.shadingShiftTexture = mtoon.shadingShiftTexture.map(MToonMaterialDescriptor.Texture.init)
-        self.normalTexture = material.normalTexture.map(MToonMaterialDescriptor.Texture.init)
+        self.normalTexture = standard.normalTexture
         self.matcapTexture = mtoon.matcapTexture.map(MToonMaterialDescriptor.Texture.init)
         self.rimMultiplyTexture = mtoon.rimMultiplyTexture.map(MToonMaterialDescriptor.Texture.init)
         self.outlineWidthMultiplyTexture = mtoon.outlineWidthMultiplyTexture.map(MToonMaterialDescriptor.Texture.init)

--- a/Sources/VRMKitRuntime/StandardMToonConverter.swift
+++ b/Sources/VRMKitRuntime/StandardMToonConverter.swift
@@ -1,0 +1,58 @@
+import VRMKit
+
+/// Synthesizes an ``MToonMaterialDescriptor`` from a standard Unlit / PBR glTF
+/// material, the way ``VRM0MToonMigrator`` does from a VRM 0.x property.
+package enum StandardMToonConverter {
+    package static func migrate(material: GLTF.Material,
+                                vrm0Property: VRM0.MaterialProperty?,
+                                shadeColorScale: Float,
+                                shadingToonyFactor: Float,
+                                shadingShiftFactor: Float,
+                                outlineWidthFactor: Float,
+                                outlineColorFactor: SIMD4<Float>) -> MToonMaterialDescriptor {
+        typealias SpecDefault = MToonMaterialDescriptor.SpecDefault
+        let standard = MToonMaterialDescriptor.StandardMaterialProperties(material)
+        let base = standard.baseColorFactor
+        let shadeColor = SIMD4<Float>(SIMD3<Float>(base.x, base.y, base.z) * shadeColorScale, 1)
+        let hasOutline = outlineWidthFactor > 0
+
+        return MToonMaterialDescriptor(
+            baseColorFactor: standard.baseColorFactor,
+            emissiveFactor: standard.emissiveFactor,
+            shadeColorFactor: shadeColor,
+            shadingShiftFactor: shadingShiftFactor,
+            shadingShiftTextureScale: SpecDefault.shadingShiftTextureScale,
+            shadingToonyFactor: shadingToonyFactor,
+            giEqualizationFactor: SpecDefault.giEqualizationFactor,
+            matcapFactor: SpecDefault.matcapFactor,
+            parametricRimColorFactor: SpecDefault.parametricRimColorFactor,
+            rimLightingMixFactor: SpecDefault.rimLightingMixFactor,
+            parametricRimFresnelPowerFactor: SpecDefault.parametricRimFresnelPowerFactor,
+            parametricRimLiftFactor: SpecDefault.parametricRimLiftFactor,
+            outlineWidthMode: hasOutline ? .worldCoordinates : .none,
+            outlineWidthFactor: outlineWidthFactor,
+            outlineColorFactor: outlineColorFactor,
+            outlineLightingMixFactor: SpecDefault.outlineLightingMixFactor,
+            uvAnimationScrollXSpeedFactor: SpecDefault.uvAnimationSpeedFactor,
+            uvAnimationScrollYSpeedFactor: SpecDefault.uvAnimationSpeedFactor,
+            uvAnimationRotationSpeedFactor: SpecDefault.uvAnimationSpeedFactor,
+            transparentWithZWrite: SpecDefault.transparentWithZWrite,
+            renderQueueOffsetNumber: SpecDefault.renderQueueOffsetNumber,
+            // A VRM 0.x non-MToon material carries its transparency in the Unity
+            // property, resolved the same way as the built-in Unlit / PBR path.
+            alphaMode: GLTF.Material.AlphaMode(vrm0: vrm0Property, fallback: standard.alphaMode),
+            alphaCutoff: standard.alphaCutoff,
+            cullMode: standard.cullMode,
+            normalScale: standard.normalScale,
+            baseColorTexture: standard.baseColorTexture,
+            emissiveTexture: standard.emissiveTexture,
+            shadeMultiplyTexture: standard.baseColorTexture,
+            shadingShiftTexture: nil,
+            normalTexture: standard.normalTexture,
+            matcapTexture: nil,
+            rimMultiplyTexture: nil,
+            outlineWidthMultiplyTexture: nil,
+            uvAnimationMaskTexture: nil
+        )
+    }
+}

--- a/Sources/VRMRealityKit/CustomType/GLTFEntity.swift
+++ b/Sources/VRMRealityKit/CustomType/GLTFEntity.swift
@@ -13,7 +13,7 @@ struct GLTFComponent: Component {
 }
 
 /// The glTF node a loaded entity was built from. The array index is a node's
-/// canonical identity — `name` is optional and may repeat.
+/// canonical identity, since `name` is optional and may repeat.
 @available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 public struct GLTFNodeComponent: Component {
     public let nodeIndex: Int
@@ -161,8 +161,8 @@ public class GLTFEntity: Entity {
     /// Re-applies the skeletal pose of every skin binding from the current joint
     /// entity transforms.
     func updateSkinning() {
-        // Bindings sharing a skeleton and model world transform — a mesh and its
-        // outline twin, say — resolve to identical joint transforms.
+        // Bindings sharing a skeleton and model world transform, such as a mesh
+        // and its outline twin, resolve to identical joint transforms.
         var solved: [String: (modelWorld: simd_float4x4, transforms: JointTransforms)] = [:]
         for binding in skinBindings {
             let modelWorld = binding.modelEntity.transformMatrix(relativeTo: nil)
@@ -223,9 +223,9 @@ extension ModelEntity {
     func applyMorphWeights(_ weights: [Float]) {
         let current = blendWeights
         guard !current.isEmpty else { return }
-        // Compared before any copy: a held pose — a STEP segment, a paused
-        // animation — is the common case, and writing the sets would copy them
-        // and re-upload the weights for nothing.
+        // Compared before any copy: a held pose, from a STEP segment or a
+        // paused animation, is the common case, and writing the sets would copy
+        // them and re-upload the weights for nothing.
         func differs(_ set: [Float]) -> Bool {
             weights.enumerated().contains { targetIndex, weight in
                 targetIndex < set.count && set[targetIndex] != weight

--- a/Sources/VRMRealityKit/CustomType/VRMEntity.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMEntity.swift
@@ -43,12 +43,14 @@ public final class VRMEntity: GLTFEntity {
     private var textureTransformClips: [ExpressionKey: [TextureTransformBinding]] = [:]
     private var firstPersonAnnotations: [FirstPersonAnnotation] = []
     /// Everything the runtime tracks per glTF material. Keying this by material
-    /// index — rather than copying it onto every entity — is what keeps the
-    /// MToon parameter rows single-source.
+    /// index, rather than copying it onto every entity, is what keeps the
+    /// animatable shader parameters single-source.
     private struct MaterialRuntimeState {
         var modelEntities: [ModelEntity] = []
-        var mtoonParameters: MToonMaterialParameters?
-        var needsMToonParameterFlush = false
+        /// The mutable shader parameters of the material, when what renders it
+        /// makes a state for it, as MToon does.
+        var animatable: (any VRMAnimatableMaterialState)?
+        var needsFlush = false
     }
 
     private var materialStates: [Int: MaterialRuntimeState] = [:]
@@ -169,8 +171,9 @@ public final class VRMEntity: GLTFEntity {
                         guard bind.targetValue.count >= 3 else { return nil }
                         // A malformed bind (e.g. out-of-range material index) only
                         // invalidates that bind, never the whole model load.
-                        guard let baseValue = try? loader.currentMaterialColor(withMaterialIndex: bind.material,
-                                                                               type: bind.type) else {
+                        guard let baseValue = try? currentMaterialColor(withMaterialIndex: bind.material,
+                                                                        type: bind.type,
+                                                                        loader: loader) else {
                             Self.logger.warning("""
                             Skipping invalid MaterialColorBind. \
                             expression=\(expressionClip.name, privacy: .public) \
@@ -189,7 +192,8 @@ public final class VRMEntity: GLTFEntity {
 
                 let transformBindings: [TextureTransformBinding] = expressionClip.expression.textureTransformBinds?
                     .compactMap { bind in
-                        guard let base = try? loader.currentTextureTransform(withMaterialIndex: bind.material) else {
+                        guard let base = try? currentTextureTransform(withMaterialIndex: bind.material,
+                                                                      loader: loader) else {
                             return nil
                         }
                         return TextureTransformBinding(materialIndex: bind.material,
@@ -345,12 +349,13 @@ public final class VRMEntity: GLTFEntity {
         self.springBones = springBones
     }
 
-    /// Registers an entity as a renderer of `materialIndex`. The MToon parameter
-    /// rows are resolved once per material, so every entity sharing it shares them.
+    /// Registers an entity as a renderer of `materialIndex`. The animatable
+    /// shader parameters are resolved once per material, so every entity sharing
+    /// it shares them.
     override func registerMaterialBinding(modelEntity: ModelEntity, materialIndex: Int, loader: GLTFEntityLoader) {
         if materialStates[materialIndex] == nil {
             materialStates[materialIndex] = MaterialRuntimeState(
-                mtoonParameters: try? loader.mtoonParameters(withMaterialIndex: materialIndex)
+                animatable: loader.makeAnimatableMaterialState(forMaterialIndex: materialIndex)
             )
         }
         materialStates[materialIndex]?.modelEntities.append(modelEntity)
@@ -359,14 +364,41 @@ public final class VRMEntity: GLTFEntity {
     /// The MToon parameter rows a material renders with, or nil when it does
     /// not render as MToon.
     func mtoonParameters(forMaterialIndex index: Int) -> MToonMaterialParameters? {
-        materialStates[index]?.mtoonParameters
+        mtoonState(forMaterialIndex: index)?.parameters
+    }
+
+    /// The color a `materialColorBind` starts from. A state animating that color
+    /// (MToon animates them all) keeps it; everything else reads it from the
+    /// RealityKit material.
+    func currentMaterialColor(withMaterialIndex index: Int,
+                              type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType,
+                              loader: GLTFEntityLoader) throws -> SIMD4<Float> {
+        if let color = materialStates[index]?.animatable?.color(for: type) {
+            return color
+        }
+        return try loader.material(withMaterialIndex: index).currentColor(for: type)
+    }
+
+    /// The UV transform a `textureTransformBind` starts from. A state animating
+    /// it (MToon does) keeps it; everything else reads it from the RealityKit
+    /// material.
+    func currentTextureTransform(withMaterialIndex index: Int,
+                                 loader: GLTFEntityLoader) throws -> MaterialParameterTypes.TextureCoordinateTransform {
+        if let transform = materialStates[index]?.animatable?.textureTransform {
+            return transform
+        }
+        return try loader.material(withMaterialIndex: index).currentTextureTransform
+    }
+
+    private func mtoonState(forMaterialIndex index: Int) -> MToonAnimatableMaterialState? {
+        materialStates[index]?.animatable as? MToonAnimatableMaterialState
     }
 
     /// Advances spring bones, node constraints, and skinning by one frame.
     ///
     /// ``VRMUpdateSystem`` calls this automatically once per render frame, so
     /// there is normally no need to call it. To drive the timing manually, set
-    /// ``isAutomaticUpdateEnabled`` to `false` first — otherwise the model
+    /// ``isAutomaticUpdateEnabled`` to `false` first, otherwise the model
     /// advances twice per frame.
     public func update(deltaTime: TimeInterval) {
         let deltaTime = max(0, deltaTime)
@@ -386,13 +418,12 @@ public final class VRMEntity: GLTFEntity {
         guard simd_distance(normalized, mtoonLightDirection) > 0.0001 else { return }
         mtoonLightDirection = normalized
         // The direction rides in custom.value rather than in a parameter row, so
-        // it reaches the materials without rebuilding their packed texture — and
+        // it reaches the materials without rebuilding their packed texture, and
         // without clearing a rebuild an earlier row change is still waiting for.
         for materialIndex in materialStates.keys {
-            guard var parameters = materialStates[materialIndex]?.mtoonParameters else { continue }
-            parameters.lightDirection = normalized
-            materialStates[materialIndex]?.mtoonParameters = parameters
-            applyMToonParameters(parameters, ofMaterial: materialIndex, parameterTexture: nil)
+            guard let state = mtoonState(forMaterialIndex: materialIndex) else { continue }
+            state.setLightDirection(normalized)
+            mapMaterials(ofMaterial: materialIndex) { state.applyLightDirection(to: $0) }
         }
     }
 
@@ -481,69 +512,64 @@ public final class VRMEntity: GLTFEntity {
     fileprivate func applyMaterialColor(_ color: SIMD4<Float>,
                                         type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType,
                                         materialIndex: Int) {
-        // MToon owns its colors in the parameter rows; the packed texture is
-        // rebuilt once per material by flushDirtyMToonParameters().
-        if mutateMToonParameters(ofMaterial: materialIndex, { $0.setColor(color, for: type) }) {
+        // A shader animating this color owns it in its own parameters, which
+        // reach the GPU once per material via flushDirtyMaterialStates(). An
+        // unclaimed color falls back below.
+        if mutateAnimatableState(ofMaterial: materialIndex, { $0.setColor(color, for: type) }) {
             return
         }
         let vrmColor = VRMColor(simd: color)
-        forEachModelEntity(ofMaterial: materialIndex) { component in
-            component.materials = component.materials.map { $0.settingColor(vrmColor, for: type) }
-        }
+        mapMaterials(ofMaterial: materialIndex) { $0.settingColor(vrmColor, for: type) }
     }
 
     fileprivate func applyTextureTransform(scale: SIMD2<Float>,
                                            offset: SIMD2<Float>,
                                            rotation: Float,
                                            materialIndex: Int) {
-        // MToon applies the UV transform in its own shader from the parameter
-        // rows; writing RealityKit's material-level transform too would
-        // transform the primary UV twice. Fallback materials have no such
-        // shader, so they use the material-level transform.
-        if mutateMToonParameters(ofMaterial: materialIndex, {
+        // A shader animating the UV transform applies it itself from its
+        // parameters; writing RealityKit's material-level transform too would
+        // transform the primary UV twice. Everything else, fallback materials
+        // included, uses the material-level transform.
+        if mutateAnimatableState(ofMaterial: materialIndex, {
             $0.setTextureTransform(scale: scale, offset: offset, rotation: rotation)
         }) {
             return
         }
-        forEachModelEntity(ofMaterial: materialIndex) { component in
-            component.materials = component.materials.map {
-                $0.settingTextureTransform(scale: scale, offset: offset, rotation: rotation)
-            }
+        mapMaterials(ofMaterial: materialIndex) {
+            $0.settingTextureTransform(scale: scale, offset: offset, rotation: rotation)
         }
     }
 
-    // MARK: - MToon runtime state
+    // MARK: - Animatable material runtime state
     //
-    // MToon parameters describe a *material*, not an entity, so they are stored
+    // Shader parameters describe a *material*, not an entity, so they are stored
     // once per material index and pushed to every entity that renders with it.
     // visionOS has no `CustomMaterial`, so no material has them and these all
     // no-op there without platform conditionals of their own.
 
-    /// Edits a material's MToon parameter rows, marking its packed texture for
-    /// rebuild. Returns false when the material does not render as MToon, which
-    /// is the caller's cue to fall back to the RealityKit material properties.
-    @discardableResult
-    private func mutateMToonParameters(ofMaterial materialIndex: Int,
-                                       _ mutate: (inout MToonMaterialParameters) -> Void) -> Bool {
-        guard var parameters = materialStates[materialIndex]?.mtoonParameters else { return false }
-        mutate(&parameters)
-        materialStates[materialIndex]?.mtoonParameters = parameters
-        materialStates[materialIndex]?.needsMToonParameterFlush = true
+    /// Edits a material's animatable shader state, marking it for flush. Returns
+    /// false when no such state renders the material, or when it does not animate
+    /// the value `mutate` writes: the caller's cue to fall back to the RealityKit
+    /// material properties.
+    private func mutateAnimatableState(ofMaterial materialIndex: Int,
+                                       _ mutate: (any VRMAnimatableMaterialState) -> Bool) -> Bool {
+        guard let animatable = materialStates[materialIndex]?.animatable,
+              mutate(animatable) else { return false }
+        materialStates[materialIndex]?.needsFlush = true
         return true
     }
 
-    /// Rebuilds the packed parameter texture once per material whose rows
-    /// changed, instead of once per binding that touched it.
-    private func flushDirtyMToonParameters() {
-        for (materialIndex, state) in materialStates where state.needsMToonParameterFlush {
-            guard let parameters = state.mtoonParameters,
-                  let parameterTexture = parameterTextureResource(for: parameters) else {
+    /// Pushes each dirty material's pending parameter writes to the GPU once per
+    /// material, instead of once per binding that touched it.
+    private func flushDirtyMaterialStates() {
+        for (materialIndex, state) in materialStates where state.needsFlush {
+            guard let animatable = state.animatable, animatable.prepareFlush() else {
                 // The GPU still holds the previous values, so the material stays
-                // dirty and the next flush retries building its texture.
+                // dirty and the next flush retries.
                 continue
             }
-            applyMToonParameters(parameters, ofMaterial: materialIndex, parameterTexture: parameterTexture)
-            materialStates[materialIndex]?.needsMToonParameterFlush = false
+            mapMaterials(ofMaterial: materialIndex) { animatable.apply(to: $0) }
+            materialStates[materialIndex]?.needsFlush = false
         }
     }
 
@@ -552,61 +578,22 @@ public final class VRMEntity: GLTFEntity {
     /// they take the same dirty-and-flush path as expression-driven row changes.
     private func updateMToonLightingRows() {
         for materialIndex in materialStates.keys {
-            mutateMToonParameters(ofMaterial: materialIndex) { parameters in
-                parameters.lightColor = SIMD4<Float>(mtoonLightColor, 1)
-                parameters.ambientColor = SIMD4<Float>(mtoonAmbientColor, 1)
-            }
+            guard let state = mtoonState(forMaterialIndex: materialIndex) else { continue }
+            state.setLighting(color: mtoonLightColor, ambient: mtoonAmbientColor)
+            materialStates[materialIndex]?.needsFlush = true
         }
-        flushDirtyMToonParameters()
+        flushDirtyMaterialStates()
     }
 
-    private func applyMToonParameters(_ parameters: MToonMaterialParameters,
-                                      ofMaterial materialIndex: Int,
-                                      parameterTexture: TextureResource?) {
-        forEachModelEntity(ofMaterial: materialIndex) { component in
-            component.materials = component.materials.map {
-                applyingMToonParameters(parameters, to: $0, parameterTexture: parameterTexture)
-            }
-        }
-    }
-
-    /// Applies `edit` to the `ModelComponent` of every entity rendering with
-    /// `materialIndex`, writing the component back.
-    private func forEachModelEntity(ofMaterial materialIndex: Int,
-                                    _ edit: (inout ModelComponent) -> Void) {
+    /// Rewrites the materials of every entity rendering with `materialIndex`
+    /// through `transform`, writing the model components back.
+    private func mapMaterials(ofMaterial materialIndex: Int,
+                              _ transform: (any Material) -> any Material) {
         guard let modelEntities = materialStates[materialIndex]?.modelEntities else { return }
         for modelEntity in modelEntities {
             guard var component = modelEntity.components[ModelComponent.self] else { continue }
-            edit(&component)
+            component.materials = component.materials.map(transform)
             modelEntity.components.set(component)
-        }
-    }
-
-    /// MToon parameters live on `CustomMaterial`, which visionOS does not have,
-    /// so this is the single platform boundary of the runtime update path.
-    private func applyingMToonParameters(_ parameters: MToonMaterialParameters,
-                                         to material: any Material,
-                                         parameterTexture: TextureResource?) -> any Material {
-#if os(visionOS)
-        return material
-#else
-        guard var material = material as? CustomMaterial else { return material }
-        material.custom.value = parameters.customValue
-        if let parameterTexture {
-            material.custom.texture = CustomMaterial.Texture(parameterTexture)
-        }
-        return material
-#endif
-    }
-
-    /// Packs the parameter rows into one GPU texture. Callers build it once per
-    /// material and share it across every entity that renders with it.
-    private func parameterTextureResource(for parameters: MToonMaterialParameters) -> TextureResource? {
-        do {
-            return try parameters.textureResource()
-        } catch {
-            Self.logger.error("Failed to update MToon parameter texture: \(error.localizedDescription, privacy: .public)")
-            return nil
         }
     }
 
@@ -702,7 +689,7 @@ public final class VRMEntity: GLTFEntity {
                                   materialIndex: materialIndex)
         }
 
-        flushDirtyMToonParameters()
+        flushDirtyMaterialStates()
     }
 
     /// Where one blend-shape target lives in a model entity's weight sets.

--- a/Sources/VRMRealityKit/CustomType/VRMUpdateSystem.swift
+++ b/Sources/VRMRealityKit/CustomType/VRMUpdateSystem.swift
@@ -17,8 +17,8 @@ struct VRMUpdateComponent: Component {}
 /// The system is registered automatically the first time a ``VRMEntity`` is
 /// created, so a model animates as soon as it is added to a scene, without any
 /// per-frame code on the caller's side. To run your own animation code in a
-/// guaranteed order relative to the VRM update — for example, posing joints that
-/// this frame's skinning should already reflect — declare it in a custom
+/// guaranteed order relative to the VRM update, for example posing joints that
+/// this frame's skinning should already reflect, declare it in a custom
 /// `System` with `SystemDependency.before(VRMUpdateSystem.self)`.
 @available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
 public struct VRMUpdateSystem: System {

--- a/Sources/VRMRealityKit/EntityData.swift
+++ b/Sources/VRMRealityKit/EntityData.swift
@@ -29,7 +29,8 @@ final class EntityData {
     }
 
     var skins: [Skin?]
-    var materials: [Material?] = []
+    /// One glTF material resolved through the shader chain: what it renders as.
+    var materials: [GLTFShadedMaterial?] = []
     var images: [VRMImage?] = []
 
     init(gltf: GLTF) {

--- a/Sources/VRMRealityKit/GLTF2RealityKit/GLTF2RealityKit.swift
+++ b/Sources/VRMRealityKit/GLTF2RealityKit/GLTF2RealityKit.swift
@@ -35,4 +35,22 @@ extension GLTF.Color4 {
         VRMColor(red: CGFloat(r), green: CGFloat(g), blue: CGFloat(b), alpha: CGFloat(a))
     }
 }
+
+/// The glTF alpha-mode → RealityKit blending decision, shared by every
+/// material path: the built-in Unlit / PBR one and MToon's `CustomMaterial`.
+struct GLTFAlphaModeSettings {
+    let isTransparent: Bool
+    let opacityThreshold: Float?
+
+    init(_ mode: GLTF.Material.AlphaMode, alphaCutoff: Float) {
+        switch mode {
+        case .OPAQUE:
+            (isTransparent, opacityThreshold) = (false, nil)
+        case .MASK:
+            (isTransparent, opacityThreshold) = (false, alphaCutoff)
+        case .BLEND:
+            (isTransparent, opacityThreshold) = (true, nil)
+        }
+    }
+}
 #endif

--- a/Sources/VRMRealityKit/GLTF2RealityKit/GLTFSampler+Metal.swift
+++ b/Sources/VRMRealityKit/GLTF2RealityKit/GLTFSampler+Metal.swift
@@ -1,0 +1,44 @@
+#if canImport(Metal)
+import Metal
+import VRMKit
+
+extension GLTF.Sampler.MagFilter {
+    var metalFilter: MTLSamplerMinMagFilter {
+        switch self {
+        case .NEAREST: return .nearest
+        case .LINEAR: return .linear
+        }
+    }
+}
+
+extension GLTF.Sampler.MinFilter {
+    /// glTF's `minFilter` encodes both the minification texel filter and the
+    /// mip filter, which Metal keeps separate.
+    var metalFilters: (min: MTLSamplerMinMagFilter, mip: MTLSamplerMipFilter) {
+        switch self {
+        case .NEAREST:
+            return (.nearest, .notMipmapped)
+        case .LINEAR:
+            return (.linear, .notMipmapped)
+        case .NEAREST_MIPMAP_NEAREST:
+            return (.nearest, .nearest)
+        case .LINEAR_MIPMAP_NEAREST:
+            return (.linear, .nearest)
+        case .NEAREST_MIPMAP_LINEAR:
+            return (.nearest, .linear)
+        case .LINEAR_MIPMAP_LINEAR:
+            return (.linear, .linear)
+        }
+    }
+}
+
+extension GLTF.Sampler.Wrap {
+    var metalAddressMode: MTLSamplerAddressMode {
+        switch self {
+        case .CLAMP_TO_EDGE: return .clampToEdge
+        case .MIRRORED_REPEAT: return .mirrorRepeat
+        case .REPEAT: return .repeat
+        }
+    }
+}
+#endif

--- a/Sources/VRMRealityKit/GLTFEntityLoader.swift
+++ b/Sources/VRMRealityKit/GLTFEntityLoader.swift
@@ -23,7 +23,6 @@ public class GLTFEntityLoader {
     /// Name given to the loaded root entity. Subclasses set it from model metadata.
     var entityName: String?
     weak var currentEntity: GLTFEntity?
-    static let logger = Logger(subsystem: "dev.tattn.VRMKit", category: "MToon")
     static let gltfLogger = Logger(subsystem: "dev.tattn.VRMKit", category: "glTF")
 
     private var didValidateStructure = false
@@ -34,7 +33,7 @@ public class GLTFEntityLoader {
     private var materialTexCoordCache: [Int: (selected: Int, isMixed: Bool)] = [:]
     private var morphTargetCounts: [Int: Int] = [:]
 
-    private func logOnce(_ key: String, _ message: @autoclosure () -> String) {
+    func logOnce(_ key: String, _ message: @autoclosure () -> String) {
         guard loggedLimitations.insert(key).inserted else { return }
         let text = message()
         Self.gltfLogger.warning("\(text, privacy: .public)")
@@ -53,66 +52,45 @@ public class GLTFEntityLoader {
 
     private var bakedTextureCache: [BakedTextureKey: TextureResource] = [:]
     private var samplerCache: [Int: MaterialParameters.Texture.Sampler] = [:]
-    private var fallbackTextureCache: [MToonTextureSlot.Fallback: TextureResource] = [:]
-    private var mtoonDescriptorCache: [Int: MToonMaterialDescriptor?] = [:]
-#if !os(visionOS)
-    /// Everything derived from one MToon material. A non-nil state is what
-    /// "this material renders as MToon" means.
-    private struct MToonState {
-        let descriptor: MToonMaterialDescriptor
-        let parameters: MToonMaterialParameters
-        let parameterTexture: CustomMaterial.Texture
-        let library: MTLLibrary
-    }
+    private var mtoonResolutionCache: [Int: MToonMaterialDescriptor.Resolution] = [:]
 
-    private var mtoonStateCache: [Int: MToonState?] = [:]
-    private var mtoonOutlineMaterialCache: [Int: Material?] = [:]
-#endif
-    private var loggedMToonLibraryError = false
-    /// When `false`, MToon materials are not created and the loader falls back to Unlit / PBR materials.
-    /// visionOS always uses the fallback because `CustomMaterial` is unavailable there.
-    public let isMToonEnabled: Bool
-    /// Controls creation of MToon's inverted-hull outline entities.
-    /// visionOS does not create MToon outlines because `CustomMaterial` is unavailable there.
-    public let isOutlineEnabled: Bool
+    /// The material shaders this loader consults, in order. Materials no shader
+    /// claims render through the built-in Unlit / PBR path, so pass `[]` to
+    /// render everything that way.
+    public let shaders: [any GLTFMaterialShader]
+
+    /// The default shader chain: MToon for materials that carry MToon data.
+    /// Computed so every loader gets its own shader instances.
+    public static var defaultShaders: [any GLTFMaterialShader] { [MToonShader()] }
+
     public init(document: GLTFDocument,
-                isMToonEnabled: Bool = true,
-                isOutlineEnabled: Bool = true) {
+                shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) {
         self.document = document
         self.entityData = EntityData(gltf: document.gltf)
         self.accessors = PackedAccessorCache(document: document)
-        self.isMToonEnabled = isMToonEnabled
-        self.isOutlineEnabled = isOutlineEnabled
+        self.shaders = shaders
     }
 
     /// Loads a `.glb` / `.gltf` file. External resources resolve relative to
     /// the file's directory.
     public convenience init(withURL url: URL,
-                            isMToonEnabled: Bool = true,
-                            isOutlineEnabled: Bool = true) throws {
-        self.init(document: try GLTFLoader().load(withURL: url),
-                  isMToonEnabled: isMToonEnabled,
-                  isOutlineEnabled: isOutlineEnabled)
+                            shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) throws {
+        self.init(document: try GLTFLoader().load(withURL: url), shaders: shaders)
     }
 
     /// Loads a bundled glTF resource.
     public convenience init(named: String,
-                            isMToonEnabled: Bool = true,
-                            isOutlineEnabled: Bool = true) throws {
-        self.init(document: try GLTFLoader().load(named: named),
-                  isMToonEnabled: isMToonEnabled,
-                  isOutlineEnabled: isOutlineEnabled)
+                            shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) throws {
+        self.init(document: try GLTFLoader().load(named: named), shaders: shaders)
     }
 
     /// Loads in-memory glTF data. `rootDirectory` is the base directory for
     /// external resources.
     public convenience init(withData data: Data,
                             rootDirectory: URL? = nil,
-                            isMToonEnabled: Bool = true,
-                            isOutlineEnabled: Bool = true) throws {
+                            shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) throws {
         self.init(document: try GLTFLoader().load(withData: data, rootDirectory: rootDirectory),
-                  isMToonEnabled: isMToonEnabled,
-                  isOutlineEnabled: isOutlineEnabled)
+                  shaders: shaders)
     }
 
     /// Loads the document's default scene.
@@ -126,7 +104,7 @@ public class GLTFEntityLoader {
     }
 
     /// Loads one scene of the glTF as its own entity graph. Every call builds a
-    /// new graph — even for the same scene — while resources are reused.
+    /// new graph, even for the same scene, while resources are reused.
     public func loadEntity(withSceneIndex index: Int) throws -> GLTFEntity {
         try validateRequiredExtensions()
         try validateStructure()
@@ -166,20 +144,16 @@ public class GLTFEntityLoader {
     /// Called once per scene, after its node hierarchy and bindings are built.
     func didBuildScene(_ entity: GLTFEntity) throws {}
 
-    /// glTF extensions this renderer implements, to satisfy `extensionsRequired`.
+    /// glTF extensions this renderer implements, to satisfy `extensionsRequired`:
+    /// the built-in ones plus whatever the shader chain claims.
     ///
     /// Not an override point outside this module: claiming an extension this
     /// renderer cannot draw would only silence the check that rejects it.
     public var supportedRequiredExtensions: Set<String> {
         var extensions: Set<String> = ["KHR_materials_unlit", "KHR_texture_transform"]
-        // MToon renders through CustomMaterial and a precompiled Metal library, so
-        // a platform without either — visionOS, Mac Catalyst — cannot claim it, and
-        // neither can a loader with MToon turned off.
-#if !os(visionOS)
-        if isMToonEnabled, MToonShaderLibraryLoader.resourceName != nil {
-            extensions.insert("VRMC_materials_mtoon")
+        for shader in shaders {
+            extensions.formUnion(shader.supportedRequiredExtensions)
         }
-#endif
         return extensions
     }
 
@@ -190,20 +164,34 @@ public class GLTFEntityLoader {
         if let unsupported = unsupportedRequiredExtensions().first {
             throw VRMError._notSupported("this glTF requires the \(unsupported) extension")
         }
-        if gltf.extensionsRequired?.contains("KHR_texture_transform") == true {
+        if enforcesRequiredExtension("KHR_texture_transform") {
             try validateTextureTransformsAreRenderable()
         }
     }
 
-    /// RealityKit gives a material one UV transform, so `KHR_texture_transform` is
-    /// only fully implemented while a material's textures agree on theirs.
+    /// RealityKit gives a material one UV transform, and its mesh one UV set, so
+    /// `KHR_texture_transform` is only fully implemented while a material's
+    /// textures agree on both; the extension's `texCoord` overrides the texture
+    /// info's, so the UV set is as much part of it as the transform.
     ///
     /// An asset that merely *uses* the extension renders through the first
-    /// transform and logs the approximation; one that *requires* it is asking for
-    /// a result this renderer cannot draw, so it is rejected instead.
+    /// UV-accessed texture's set and transform and logs the approximation; one
+    /// that *requires* it is asking for a result this renderer cannot draw, so it
+    /// is rejected instead.
+    ///
+    /// This covers the textures of the core glTF material. A shader sampling
+    /// textures the core material does not name, such as MToon's shade and rim
+    /// maps, checks those itself against the same limits.
     private func validateTextureTransformsAreRenderable() throws {
         for (index, gltfMaterial) in (gltf.materials ?? []).enumerated() {
-            let transforms = sampledTextures(of: gltfMaterial).map { $0.transform ?? GLTFUVTransform() }
+            let textures = sampledTextures(of: gltfMaterial)
+            let selectedTexCoord = selectedTexCoord(withMaterialIndex: index)
+            guard textures.allSatisfy({ $0.texCoord == selectedTexCoord }) else {
+                throw VRMError._notSupported(
+                    "this glTF requires KHR_texture_transform, and material \(index) samples UV sets other than \(selectedTexCoord), which this renderer cannot draw"
+                )
+            }
+            let transforms = textures.map { $0.transform ?? GLTFUVTransform() }
             guard transforms.allSatisfy({ $0 == transforms.first }) else {
                 throw VRMError._notSupported(
                     "this glTF requires KHR_texture_transform, and material \(index) gives its textures different transforms, which this renderer cannot draw"
@@ -212,9 +200,21 @@ public class GLTFEntityLoader {
         }
     }
 
+    /// Whether the document declares itself undrawable without `name` *and* this
+    /// load honors that declaration. It is the signal for a shader to fail a
+    /// material rather than draw an approximation of it.
+    ///
+    /// ``VRMEntityLoader`` renders a VRM with whatever it can build, so it
+    /// answers false even for a listed extension, matching its
+    /// ``VRMEntityLoader/validateRequiredExtensions()``.
+    func enforcesRequiredExtension(_ name: String) -> Bool {
+        gltf.extensionsRequired?.contains(name) == true
+    }
+
     /// `extensionsRequired` entries outside ``supportedRequiredExtensions``.
     func unsupportedRequiredExtensions() -> [String] {
-        (gltf.extensionsRequired ?? []).filter { !supportedRequiredExtensions.contains($0) }
+        let supported = supportedRequiredExtensions
+        return (gltf.extensionsRequired ?? []).filter { !supported.contains($0) }
     }
 
     /// Rejects, once per document, the malformed node graphs and skins the rest
@@ -341,8 +341,8 @@ public class GLTFEntityLoader {
         return targetCount
     }
 
-    /// Applies the spec's starting morph state — `node.weights`, falling back to
-    /// `mesh.weights` — so the first frame renders correctly without animation.
+    /// Applies the spec's starting morph state, `node.weights` falling back to
+    /// `mesh.weights`, so the first frame renders correctly without animation.
     ///
     /// Both are sized by the mesh's morph target count; another length means the
     /// file and this renderer disagree about what the weights stand for.
@@ -426,7 +426,9 @@ public class GLTFEntityLoader {
         meshEntity.name = gltfMesh.name ?? "mesh_\(index)"
 
         for primitive in resolvedPrimitives(of: gltfMesh) {
-            if let primitiveEntity = try modelEntity(withPrimitive: primitive, skinIndex: skinIndex) {
+            if let primitiveEntity = try modelEntity(withPrimitive: primitive,
+                                                     skinIndex: skinIndex,
+                                                     meshName: meshEntity.name) {
                 meshEntity.addChild(primitiveEntity)
             }
         }
@@ -439,7 +441,9 @@ public class GLTFEntityLoader {
         mesh.primitives
     }
 
-    private func modelEntity(withPrimitive primitive: GLTF.Mesh.Primitive, skinIndex: Int?) throws -> Entity? {
+    private func modelEntity(withPrimitive primitive: GLTF.Mesh.Primitive,
+                             skinIndex: Int?,
+                             meshName: String) throws -> Entity? {
         guard supportsTriangles(primitive.mode) else {
             logOnce("primitiveMode-\(primitive.mode)", """
                 A \(primitive.mode) primitive was skipped; RealityKit meshes render triangles only.
@@ -545,8 +549,8 @@ public class GLTFEntityLoader {
                                         indices: indexData,
                                         materialIndex: primitive.material)
 
-        let material = try primitive.material.map { try primitiveMaterial(withMaterialIndex: $0) }
-            ?? defaultMaterial()
+        let shaded = try primitive.material.map { try primitiveShadedMaterial(withMaterialIndex: $0) }
+            ?? GLTFShadedMaterial(material: defaultMaterial())
 
         // A skinned primitive binds its vertex influences to the skin's skeleton;
         // an unskinned one has neither.
@@ -586,18 +590,39 @@ public class GLTFEntityLoader {
             return entity
         }
 
-        let modelEntity = makeEntity(materials: [material])
-        if let materialIndex = primitive.material,
-           let outlineMaterial = try mtoonOutlineMaterial(withMaterialIndex: materialIndex) {
-            let outlineEntity = makeEntity(materials: [outlineMaterial])
-            outlineEntity.name = "\(modelEntity.name)_outline"
+        let modelEntity = makeEntity(materials: [shaded.material])
+        if !shaded.additionalPasses.isEmpty {
             let container = Entity()
-            container.name = "\(modelEntity.name)_container"
-            container.addChild(outlineEntity)
+            container.name = "\(meshName)_container"
+            for pass in shaded.additionalPasses {
+                let passEntity = makeEntity(materials: [pass.material])
+                passEntity.name = "\(meshName)_\(pass.name)"
+                container.addChild(passEntity)
+            }
             container.addChild(modelEntity)
             return container
         }
         return modelEntity
+    }
+
+    /// The UV set the meshes rendering `index` carry, and whether the material's
+    /// textures disagree about it. Custom meshes carry a single UV channel, so
+    /// the core material's first UV-accessed texture decides it.
+    private func resolvedTexCoord(withMaterialIndex index: Int) -> (selected: Int, isMixed: Bool) {
+        if let cached = materialTexCoordCache[index] { return cached }
+        guard let gltfMaterial = try? gltf.load(\.materials, at: index) else { return (0, false) }
+        let textures = sampledTextures(of: gltfMaterial)
+        let resolved = (selected: textures.first?.texCoord ?? 0,
+                        isMixed: textures.contains { $0.texCoord != textures.first?.texCoord })
+        materialTexCoordCache[index] = resolved
+        return resolved
+    }
+
+    /// The UV set the meshes rendering `index` feed RealityKit, decided by the
+    /// core glTF material. A shader sampling any other set renders through this
+    /// one, since the mesh carries no second UV channel to sample.
+    func selectedTexCoord(withMaterialIndex index: Int) -> Int {
+        resolvedTexCoord(withMaterialIndex: index).selected
     }
 
     /// The UV set this primitive's mesh feeds RealityKit. Custom meshes carry a
@@ -605,17 +630,7 @@ public class GLTFEntityLoader {
     private func texcoordAttributeKey(forMaterialIndex materialIndex: Int?,
                                       attributes: [GLTF.Mesh.Primitive.AttributeKey: Int]) -> GLTF.Mesh.Primitive.AttributeKey {
         guard let materialIndex else { return .TEXCOORD_0 }
-        let resolved: (selected: Int, isMixed: Bool)
-        if let cached = materialTexCoordCache[materialIndex] {
-            resolved = cached
-        } else {
-            guard let gltfMaterial = try? gltf.load(\.materials, at: materialIndex) else {
-                return .TEXCOORD_0
-            }
-            let textures = sampledTextures(of: gltfMaterial)
-            resolved = (textures.first?.texCoord ?? 0, textures.contains { $0.texCoord != textures.first?.texCoord })
-            materialTexCoordCache[materialIndex] = resolved
-        }
+        let resolved = resolvedTexCoord(withMaterialIndex: materialIndex)
         let selected = resolved.selected
         guard selected != 0 else { return .TEXCOORD_0 }
         let isMixed = resolved.isMixed
@@ -687,31 +702,73 @@ public class GLTFEntityLoader {
         }
     }
 
-    /// The material a primitive renders with. ``VRMEntityLoader`` overrides it to
-    /// keep rendering a model whose material this renderer cannot build.
-    func primitiveMaterial(withMaterialIndex index: Int) throws -> Material {
-        try material(withMaterialIndex: index)
+    /// The materials a primitive renders with. ``VRMEntityLoader`` overrides it
+    /// to keep rendering a model whose material this renderer cannot build.
+    func primitiveShadedMaterial(withMaterialIndex index: Int) throws -> GLTFShadedMaterial {
+        try shadedMaterial(withMaterialIndex: index)
     }
 
+    /// The main material of ``shadedMaterial(withMaterialIndex:)``.
     func material(withMaterialIndex index: Int) throws -> Material {
-        if let cache = try entityData.load(\.materials, index: index) { return cache }
-        let (gltfMaterial, materialProperty) = try materialSource(withMaterialIndex: index)
-#if !os(visionOS)
-        do {
-            if let state = try mtoonState(withMaterialIndex: index) {
-                let material = try customMToonMaterial(state)
-                entityData.materials[index] = material
-                return material
-            }
-        } catch {
-            // The fallback material is not MToon, so the state has to go with it.
-            discardMToonState(withMaterialIndex: index)
-            Self.logger.error("Failed to build the MToon material \(index, privacy: .public); falling back to Unlit / PBR: \(String(describing: error), privacy: .public)")
-        }
-#endif
+        try shadedMaterial(withMaterialIndex: index).material
+    }
 
+    /// Builds (or returns the cached) materials for one glTF material. This is
+    /// the single place "what does this material render as" is decided, so every
+    /// later question about it, the runtime state included, gets one answer.
+    func shadedMaterial(withMaterialIndex index: Int) throws -> GLTFShadedMaterial {
+        if let cached = try entityData.load(\.materials, index: index) { return cached }
+        defer { standardMaterialCache.removeValue(forKey: index) }
+        let context = try makeMaterialShaderContext(withMaterialIndex: index)
+        for shader in shaders {
+            if let shaded = try shader.makeMaterial(for: context) {
+                cacheShadedMaterial(shaded, withMaterialIndex: index)
+                return shaded
+            }
+        }
+        let shaded = GLTFShadedMaterial(material: try standardMaterial(for: context))
+        cacheShadedMaterial(shaded, withMaterialIndex: index)
+        return shaded
+    }
+
+    /// Records what a material renders as, so the shader chain runs at most once
+    /// per material. ``VRMEntityLoader`` also caches the material it falls back
+    /// to when the chain fails.
+    func cacheShadedMaterial(_ shaded: GLTFShadedMaterial, withMaterialIndex index: Int) {
+        guard entityData.materials.indices.contains(index) else { return }
+        entityData.materials[index] = shaded
+    }
+
+    func makeMaterialShaderContext(withMaterialIndex index: Int) throws -> GLTFMaterialShaderContext {
+        let (gltfMaterial, materialProperty) = try materialSource(withMaterialIndex: index)
+        return GLTFMaterialShaderContext(loader: self,
+                                         materialIndex: index,
+                                         material: gltfMaterial,
+                                         vrm0MaterialProperty: materialProperty)
+    }
+
+    /// The built-in Unlit / PBR path of the glTF core specification, rendering
+    /// every material the shader chain leaves unclaimed. Shaders can also reach
+    /// it through ``GLTFMaterialShaderContext/standardMaterial()`` to decorate
+    /// its result instead of rebuilding it. It is memoized, so a shader
+    /// inspecting it and then declining does not make the fallback rebuild it.
+    func standardMaterial(for context: GLTFMaterialShaderContext) throws -> Material {
+        if let cached = standardMaterialCache[context.materialIndex] { return cached }
+        let material = try makeStandardMaterial(for: context)
+        standardMaterialCache[context.materialIndex] = material
+        return material
+    }
+
+    private var standardMaterialCache: [Int: Material] = [:]
+
+    private func makeStandardMaterial(for context: GLTFMaterialShaderContext) throws -> Material {
+        let index = context.materialIndex
+        let gltfMaterial = context.material
+        let materialProperty = context.vrm0MaterialProperty
         let shaderName = materialProperty?.shader.lowercased()
-        let isMToon = try mtoonDescriptor(withMaterialIndex: index) != nil
+        // Unreadable MToon (an unimplemented spec version) is still MToon, so it
+        // takes the same Unlit approximation as a readable one.
+        let isMToon = try mtoonResolution(withMaterialIndex: index).isMToon
         let isUnlit = shaderName?.contains("unlit") == true || gltfMaterial.extensions?.materialsUnlit != nil
         // MToon and Unlit variants are not PBR, so both render through UnlitMaterial.
         let useUnlit = isMToon || isUnlit
@@ -735,7 +792,6 @@ public class GLTFEntityLoader {
                 material.faceCulling = .none
             }
             material.textureCoordinateTransform = standardTextureTransform(withMaterialIndex: index, of: gltfMaterial)
-            entityData.materials[index] = material
             return material
         }
 
@@ -792,7 +848,6 @@ public class GLTFEntityLoader {
         }
         material.textureCoordinateTransform = standardTextureTransform(withMaterialIndex: index, of: gltfMaterial)
 
-        entityData.materials[index] = material
         return material
     }
 
@@ -812,8 +867,8 @@ public class GLTFEntityLoader {
 
     /// The `KHR_texture_transform` a material renders with. RealityKit gives a
     /// material one UV transform, so the first UV-accessed texture's wins.
-    private func selectedUVTransform(withMaterialIndex index: Int,
-                                     textures: [GLTFSampledTexture]) -> GLTFUVTransform {
+    func selectedUVTransform(withMaterialIndex index: Int,
+                             textures: [GLTFSampledTexture]) -> GLTFUVTransform {
         let selected = textures.first?.transform ?? GLTFUVTransform()
         if textures.contains(where: { ($0.transform ?? GLTFUVTransform()) != selected }) {
             logOnce("uvTransform-\(index)", """
@@ -826,8 +881,8 @@ public class GLTFEntityLoader {
 
     /// Converts `KHR_texture_transform` into RealityKit's `textureCoordinateTransform`.
     ///
-    /// Only the rotation direction mirrors — offset and scale already act from
-    /// the corner the extension measures from — which is what
+    /// Only the rotation direction mirrors, since offset and scale already act
+    /// from the corner the extension measures from, which is what
     /// `TextureTransformRenderingTests` checks against what RealityKit draws.
     private func standardTextureTransform(withMaterialIndex index: Int,
                                           of gltfMaterial: GLTF.Material) -> MaterialParameterTypes.TextureCoordinateTransform {
@@ -838,193 +893,58 @@ public class GLTFEntityLoader {
                                                                  rotation: -transform.rotation)
     }
 
-#if !os(visionOS)
-    private func customMToonMaterial(_ state: MToonState) throws -> Material {
-        let mtoon = state.descriptor
-        let surface = CustomMaterial.SurfaceShader(named: "mtoonSurface", in: state.library)
-        var material = try CustomMaterial(surfaceShader: surface, lightingModel: .unlit)
-        // MToon needs more textures than CustomMaterial has semantic channels, so the
-        // extra slots ride on unrelated ones; MToon.metal reads them back the same way.
-        material.baseColor = .init(tint: .white, texture: try mtoonTexture(mtoon, slot: .base))
-        material.roughness.texture = try mtoonTexture(mtoon, slot: .shade)
-        material.specular.texture = try mtoonTexture(mtoon, slot: .shadingShift)
-        material.metallic.texture = try mtoonTexture(mtoon, slot: .matcap)
-        material.normal.texture = try mtoonTexture(mtoon, slot: .normal)
-        material.emissiveColor = .init(color: .white, texture: try mtoonTexture(mtoon, slot: .emissive))
-        material.clearcoatRoughness.texture = try mtoonTexture(mtoon, slot: .rim)
-        material.clearcoat.texture = try mtoonTexture(mtoon, slot: .outlineWidth)
-        material.ambientOcclusion.texture = try mtoonTexture(mtoon, slot: .uvAnimationMask)
-
-        applyAlphaMode(mtoon.alphaMode, alphaCutoff: mtoon.alphaCutoff, to: &material)
-        applyDepthWrite(mtoon, to: &material)
-        material.faceCulling = mtoon.cullMode.faceCulling
-        applyMToonParameters(state, to: &material)
-        return material
-    }
-
-    private func customMToonOutlineMaterial(_ state: MToonState) throws -> Material {
-        let mtoon = state.descriptor
-        let surface = CustomMaterial.SurfaceShader(named: "mtoonOutlineSurface", in: state.library)
-        let geometry = CustomMaterial.GeometryModifier(named: "mtoonOutlineGeometry", in: state.library)
-        var material = try CustomMaterial(surfaceShader: surface,
-                                          geometryModifier: geometry,
-                                          lightingModel: .unlit)
-        material.faceCulling = .front
-        material.baseColor = .init(tint: .white, texture: try mtoonTexture(mtoon, slot: .base))
-        material.clearcoat.texture = try mtoonTexture(mtoon, slot: .outlineWidth)
-        material.ambientOcclusion.texture = try mtoonTexture(mtoon, slot: .uvAnimationMask)
-        applyAlphaMode(mtoon.alphaMode, alphaCutoff: mtoon.alphaCutoff, to: &material)
-        applyDepthWrite(mtoon, to: &material)
-        applyMToonParameters(state, to: &material)
-        return material
-    }
-
-    /// MToon.metal applies the UV transform from the parameter rows, so
-    /// `textureCoordinateTransform` is deliberately left at identity here.
-    private func applyMToonParameters(_ state: MToonState, to material: inout CustomMaterial) {
-        material.custom.value = state.parameters.customValue
-        material.custom.texture = state.parameterTexture
-    }
-
-    /// The descriptor's texture for `slot`, or the slot's neutral fallback.
-    private func mtoonTexture(_ descriptor: MToonMaterialDescriptor,
-                              slot: MToonTextureSlot) throws -> CustomMaterial.Texture {
-        guard let texture = descriptor.texture(for: slot) else {
-            return CustomMaterial.Texture(try fallbackTextureResource(slot.fallback))
-        }
-        return CustomMaterial.Texture(try self.texture(withTextureIndex: texture.index, semantic: slot.semantic))
-    }
-#endif
-
-    func mtoonParameters(withMaterialIndex index: Int) throws -> MToonMaterialParameters? {
-#if os(visionOS)
-        return nil
-#else
-        return try mtoonState(withMaterialIndex: index)?.parameters
-#endif
-    }
-
-#if !os(visionOS)
-    private func mtoonState(withMaterialIndex index: Int) throws -> MToonState? {
-        if let cached = mtoonStateCache[index] {
+    /// What MToon data the material at `index` carries, decoded from the
+    /// `VRMC_materials_mtoon` extension or the VRM 0.x material property.
+    ///
+    /// The loader keeps this data-model knowledge even though ``MToonShader``
+    /// does the MToon rendering: the built-in fallback renders MToon-authored
+    /// materials unlit, and tangent generation asks it for the normal map VRM 0.x
+    /// keeps in Unity's `_BumpMap`.
+    func mtoonResolution(withMaterialIndex index: Int) throws -> MToonMaterialDescriptor.Resolution {
+        if let cached = mtoonResolutionCache[index] {
             return cached
         }
-        let state = try makeMToonState(withMaterialIndex: index)
-        mtoonStateCache[index] = state
-        return state
-    }
-
-    /// Records that the material does not render as MToon after all.
-    private func discardMToonState(withMaterialIndex index: Int) {
-        mtoonStateCache.updateValue(nil, forKey: index)
-        mtoonOutlineMaterialCache.updateValue(nil, forKey: index)
-    }
-
-    private func makeMToonState(withMaterialIndex index: Int) throws -> MToonState? {
-        guard isMToonEnabled,
-              let descriptor = try mtoonDescriptor(withMaterialIndex: index),
-              let library = mtoonShaderLibrary() else {
-            return nil
-        }
-        let textureTransform = mtoonTextureTransform(withMaterialIndex: index, descriptor: descriptor)
-        let parameters = try mtoonParameters(for: descriptor, textureTransform: textureTransform)
-        logMToonUnsupportedFeatures(for: descriptor, index: index)
-        return MToonState(descriptor: descriptor,
-                          parameters: parameters,
-                          parameterTexture: CustomMaterial.Texture(try parameters.textureResource()),
-                          library: library)
-    }
-
-    private func logMToonUnsupportedFeatures(for descriptor: MToonMaterialDescriptor, index: Int) {
-        if descriptor.renderQueueOffsetNumber != 0 {
-            Self.logger.warning("MToon material \(index, privacy: .public) requests renderQueueOffsetNumber \(descriptor.renderQueueOffsetNumber); RealityKit has no material-level draw-order hook, so it is ignored.")
-        }
-    }
-#endif
-
-    private func mtoonParameters(for descriptor: MToonMaterialDescriptor,
-                                 textureTransform: MaterialParameterTypes.TextureCoordinateTransform) throws -> MToonMaterialParameters {
-        var parameters = MToonMaterialParameters(descriptor)
-        parameters.setTextureTransform(scale: textureTransform.scale,
-                                       offset: textureTransform.offset,
-                                       rotation: textureTransform.rotation)
-        for slot in MToonTextureSlot.allCases {
-            try parameters.setSampler(mtoonSamplerParameters(for: descriptor.texture(for: slot)), for: slot)
-        }
-        return parameters
-    }
-
-    /// MToon.metal transforms in glTF UV space, so unlike the standard path the
-    /// transform passes through unconverted.
-    private func mtoonTextureTransform(withMaterialIndex index: Int,
-                                       descriptor: MToonMaterialDescriptor) -> MaterialParameterTypes.TextureCoordinateTransform {
-        let textures = descriptor.uvAccessedTextures
-        if textures.contains(where: { $0.texCoord != 0 }) {
-            logOnce("mtoonTexCoord-\(index)",
-                    "MToon material \(index) requests a nonzero texCoord; RealityKit uses TEXCOORD_0 on supported deployment targets.")
-        }
-        let selected = selectedUVTransform(withMaterialIndex: index, textures: textures)
-        return MaterialParameterTypes.TextureCoordinateTransform(offset: selected.offset,
-                                                                 scale: selected.scale,
-                                                                 rotation: selected.rotation)
-    }
-
-    private func mtoonOutlineMaterial(withMaterialIndex index: Int) throws -> Material? {
-#if os(visionOS)
-        return nil
-#else
-        guard isOutlineEnabled else {
-            return nil
-        }
-        if let cached = mtoonOutlineMaterialCache[index] {
-            return cached
-        }
-        let material: Material?
-        if let state = try mtoonState(withMaterialIndex: index), state.descriptor.hasOutline {
-            material = try customMToonOutlineMaterial(state)
-        } else {
-            material = nil
-        }
-        mtoonOutlineMaterialCache[index] = material
-        return material
-#endif
-    }
-
-    private func mtoonDescriptor(withMaterialIndex index: Int) throws -> MToonMaterialDescriptor? {
-        if let cached = mtoonDescriptorCache[index] {
-            return cached
-        }
-        let descriptor = try makeMToonDescriptor(withMaterialIndex: index)
-        mtoonDescriptorCache[index] = descriptor
-        return descriptor
-    }
-
-    private func makeMToonDescriptor(withMaterialIndex index: Int) throws -> MToonMaterialDescriptor? {
         let (gltfMaterial, materialProperty) = try materialSource(withMaterialIndex: index)
-        return MToonMaterialDescriptor(material: gltfMaterial, materialProperty: materialProperty)
+        let resolution = MToonMaterialDescriptor.resolve(material: gltfMaterial,
+                                                         materialProperty: materialProperty)
+        if case .unsupportedVersion(let specVersion) = resolution {
+            logOnce("mtoonSpecVersion-\(specVersion)", """
+                Material \(index) declares VRMC_materials_mtoon specVersion \(specVersion), which this \
+                renderer does not implement, so it renders as an Unlit approximation.
+                """)
+        }
+        mtoonResolutionCache[index] = resolution
+        return resolution
     }
 
-    /// The glTF material and, for VRM 0.x, the Unity material property describing it.
-    private func materialSource(withMaterialIndex index: Int) throws -> (GLTF.Material, VRM0.MaterialProperty?) {
-        let gltfMaterial = try gltf.load(\.materials, at: index)
-        return (gltfMaterial, vrm0MaterialProperty(for: gltfMaterial))
+    /// The MToon material model describing the material at `index`, or nil when
+    /// it carries none this renderer can read.
+    func mtoonDescriptor(withMaterialIndex index: Int) throws -> MToonMaterialDescriptor? {
+        try mtoonResolution(withMaterialIndex: index).descriptor
     }
+
+    /// The glTF material and, for VRM 0.x, the Unity material property
+    /// describing it, resolved once per material index.
+    private func materialSource(withMaterialIndex index: Int) throws -> (GLTF.Material, VRM0.MaterialProperty?) {
+        if let cached = materialSourceCache[index] { return cached }
+        let gltfMaterial = try gltf.load(\.materials, at: index)
+        let source = (gltfMaterial, vrm0MaterialProperty(for: gltfMaterial))
+        materialSourceCache[index] = source
+        return source
+    }
+
+    private var materialSourceCache: [Int: (GLTF.Material, VRM0.MaterialProperty?)] = [:]
 
     /// VRM 0.x compatibility hook, overridden by ``VRMEntityLoader``.
     func vrm0MaterialProperty(for gltfMaterial: GLTF.Material) -> VRM0.MaterialProperty? {
         nil
     }
 
-    private func mtoonShaderLibrary() -> MTLLibrary? {
-        do {
-            return try MToonShaderLibraryLoader.loadDefault()
-        } catch {
-            if !loggedMToonLibraryError {
-                loggedMToonLibraryError = true
-                Self.logger.error("Failed to load bundled MToon shader library: \(String(describing: error), privacy: .public)")
-            }
-            return nil
-        }
+    /// A fresh mutable runtime state for the material, made by the material on
+    /// screen: asking anything else could hand out a state describing a
+    /// material that is not.
+    func makeAnimatableMaterialState(forMaterialIndex index: Int) -> (any VRMAnimatableMaterialState)? {
+        (try? shadedMaterial(withMaterialIndex: index))?.makeAnimatableState?()
     }
 
     func texture(withTextureIndex index: Int, semantic: TextureResource.Semantic = .color) throws -> TextureResource {
@@ -1037,49 +957,14 @@ public class GLTFEntityLoader {
         return texture
     }
 
-    private func materialTexture(withTextureIndex index: Int,
-                                 semantic: TextureResource.Semantic = .color) throws -> MaterialParameters.Texture {
+    func materialTexture(withTextureIndex index: Int,
+                         semantic: TextureResource.Semantic = .color) throws -> MaterialParameters.Texture {
         let texture = try texture(withTextureIndex: index, semantic: semantic)
         let sampler = try sampler(withTextureIndex: index)
         return MaterialParameters.Texture(texture, sampler: sampler)
     }
 
-    /// The neutral 1x1 texture bound when a material omits an MToon slot.
-    private func fallbackTextureResource(_ fallback: MToonTextureSlot.Fallback) throws -> TextureResource {
-        if let cached = fallbackTextureCache[fallback] {
-            return cached
-        }
-        let texture: TextureResource
-        switch fallback {
-        case .white:
-            texture = try solidColorTextureResource(rgba: [255, 255, 255, 255], semantic: .color)
-        case .neutralNormal:
-            texture = try solidColorTextureResource(rgba: [128, 128, 255, 255], semantic: .normal)
-        }
-        fallbackTextureCache[fallback] = texture
-        return texture
-    }
-
-    private func solidColorTextureResource(rgba: [UInt8],
-                                           semantic: TextureResource.Semantic) throws -> TextureResource {
-        guard let provider = CGDataProvider(data: Data(rgba) as CFData),
-              let image = CGImage(width: 1,
-                                  height: 1,
-                                  bitsPerComponent: 8,
-                                  bitsPerPixel: 32,
-                                  bytesPerRow: 4,
-                                  space: CGColorSpaceCreateDeviceRGB(),
-                                  bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
-                                  provider: provider,
-                                  decode: nil,
-                                  shouldInterpolate: false,
-                                  intent: .defaultIntent) else {
-            throw VRMError._dataInconsistent("failed to create 1x1 \(semantic) texture")
-        }
-        return try TextureResource(image: image, options: .init(semantic: semantic))
-    }
-
-    private func sampler(withTextureIndex index: Int) throws -> MaterialParameters.Texture.Sampler {
+    func sampler(withTextureIndex index: Int) throws -> MaterialParameters.Texture.Sampler {
         if let cache = samplerCache[index] {
             return cache
         }
@@ -1091,80 +976,18 @@ public class GLTFEntityLoader {
     }
 
     /// The glTF sampler a texture references, or nil when it uses the defaults.
-    private func gltfSampler(withTextureIndex index: Int) throws -> GLTF.Sampler? {
+    func gltfSampler(withTextureIndex index: Int) throws -> GLTF.Sampler? {
         guard let samplerIndex = try gltf.load(\.textures, at: index).sampler else { return nil }
         return try gltf.load(\.samplers, at: samplerIndex)
     }
 
     private func applySampler(_ sampler: GLTF.Sampler?, to descriptor: MTLSamplerDescriptor) {
-        descriptor.magFilter = metalFilter(sampler?.magFilter ?? .LINEAR)
-        let (min, mip) = metalFilters(sampler?.minFilter ?? .LINEAR_MIPMAP_LINEAR)
+        descriptor.magFilter = (sampler?.magFilter ?? .LINEAR).metalFilter
+        let (min, mip) = (sampler?.minFilter ?? .LINEAR_MIPMAP_LINEAR).metalFilters
         descriptor.minFilter = min
         descriptor.mipFilter = mip
-        descriptor.sAddressMode = metalWrap(sampler?.wrapS ?? .REPEAT)
-        descriptor.tAddressMode = metalWrap(sampler?.wrapT ?? .REPEAT)
-    }
-
-    private func mtoonSamplerParameters(for texture: MToonMaterialDescriptor.Texture?) throws -> SIMD4<Float> {
-        guard let texture,
-              let sampler = try gltfSampler(withTextureIndex: texture.index) else {
-            return MToonMaterialParameters.defaultSampler
-        }
-        return mtoonSamplerParameters(sampler)
-    }
-
-    /// (wrapS, wrapT, filterIndex, 0), the sampler row layout `MToon.metal` expects.
-    private func mtoonSamplerParameters(_ sampler: GLTF.Sampler) -> SIMD4<Float> {
-        let (minFilter, mipFilter) = metalFilters(sampler.minFilter ?? .LINEAR_MIPMAP_LINEAR)
-        let filter = MToonSamplerFilter(
-            magnification: metalFilter(sampler.magFilter ?? .LINEAR) == .nearest ? .nearest : .linear,
-            minification: minFilter == .nearest ? .nearest : .linear,
-            mip: MToonSamplerFilter.MipFilter(mipFilter)
-        )
-        return SIMD4<Float>(mtoonWrapMode(sampler.wrapS),
-                            mtoonWrapMode(sampler.wrapT),
-                            Float(filter.index),
-                            0)
-    }
-
-    private func mtoonWrapMode(_ wrap: GLTF.Sampler.Wrap) -> Float {
-        switch wrap {
-        case .REPEAT: return 0
-        case .CLAMP_TO_EDGE: return 1
-        case .MIRRORED_REPEAT: return 2
-        }
-    }
-
-    private func metalFilter(_ filter: GLTF.Sampler.MagFilter) -> MTLSamplerMinMagFilter {
-        switch filter {
-        case .NEAREST: return .nearest
-        case .LINEAR: return .linear
-        }
-    }
-
-    private func metalFilters(_ filter: GLTF.Sampler.MinFilter) -> (min: MTLSamplerMinMagFilter, mip: MTLSamplerMipFilter) {
-        switch filter {
-        case .NEAREST:
-            return (.nearest, .notMipmapped)
-        case .LINEAR:
-            return (.linear, .notMipmapped)
-        case .NEAREST_MIPMAP_NEAREST:
-            return (.nearest, .nearest)
-        case .LINEAR_MIPMAP_NEAREST:
-            return (.linear, .nearest)
-        case .NEAREST_MIPMAP_LINEAR:
-            return (.nearest, .linear)
-        case .LINEAR_MIPMAP_LINEAR:
-            return (.linear, .linear)
-        }
-    }
-
-    private func metalWrap(_ wrap: GLTF.Sampler.Wrap) -> MTLSamplerAddressMode {
-        switch wrap {
-        case .CLAMP_TO_EDGE: return .clampToEdge
-        case .MIRRORED_REPEAT: return .mirrorRepeat
-        case .REPEAT: return .repeat
-        }
+        descriptor.sAddressMode = (sampler?.wrapS ?? .REPEAT).metalAddressMode
+        descriptor.tAddressMode = (sampler?.wrapT ?? .REPEAT).metalAddressMode
     }
 
     func image(withImageIndex index: Int) throws -> VRMImage {
@@ -1374,27 +1197,10 @@ public class GLTFEntityLoader {
         return image
     }
 
-    /// The glTF alpha-mode → RealityKit blending decision, shared by every material.
-    private struct AlphaModeSettings {
-        let isTransparent: Bool
-        let opacityThreshold: Float?
-
-        init(_ mode: GLTF.Material.AlphaMode, alphaCutoff: Float) {
-            switch mode {
-            case .OPAQUE:
-                (isTransparent, opacityThreshold) = (false, nil)
-            case .MASK:
-                (isTransparent, opacityThreshold) = (false, alphaCutoff)
-            case .BLEND:
-                (isTransparent, opacityThreshold) = (true, nil)
-            }
-        }
-    }
-
     private func applyAlphaMode(_ mode: GLTF.Material.AlphaMode,
                                 alphaCutoff: Float,
                                 to material: inout UnlitMaterial) {
-        let settings = AlphaModeSettings(mode, alphaCutoff: alphaCutoff)
+        let settings = GLTFAlphaModeSettings(mode, alphaCutoff: alphaCutoff)
         material.blending = settings.isTransparent ? .transparent(opacity: .init(scale: 1.0)) : .opaque
         material.opacityThreshold = settings.opacityThreshold
     }
@@ -1402,25 +1208,10 @@ public class GLTFEntityLoader {
     private func applyAlphaMode(_ mode: GLTF.Material.AlphaMode,
                                 alphaCutoff: Float,
                                 to material: inout PhysicallyBasedMaterial) {
-        let settings = AlphaModeSettings(mode, alphaCutoff: alphaCutoff)
+        let settings = GLTFAlphaModeSettings(mode, alphaCutoff: alphaCutoff)
         material.blending = settings.isTransparent ? .transparent(opacity: .init(scale: 1.0)) : .opaque
         material.opacityThreshold = settings.opacityThreshold
     }
-
-#if !os(visionOS)
-    private func applyAlphaMode(_ mode: GLTF.Material.AlphaMode,
-                                alphaCutoff: Float,
-                                to material: inout CustomMaterial) {
-        let settings = AlphaModeSettings(mode, alphaCutoff: alphaCutoff)
-        material.blending = settings.isTransparent ? .transparent(opacity: .init(scale: 1.0)) : .opaque
-        material.opacityThreshold = settings.opacityThreshold
-    }
-
-    /// MToon's `transparentWithZWrite` asks a blended material to still write depth.
-    private func applyDepthWrite(_ mtoon: MToonMaterialDescriptor, to material: inout CustomMaterial) {
-        material.writesDepth = mtoon.alphaMode != .BLEND || mtoon.transparentWithZWrite
-    }
-#endif
 
     /// UVs arrive V-flipped: glTF's origin is top-left, RealityKit's is bottom-left.
     private func vector2s(_ accessorIndex: Int) throws -> [SIMD2<Float>] {
@@ -1841,8 +1632,8 @@ public class GLTFEntityLoader {
     /// Gram-Schmidt against the normal, falling back to any perpendicular axis.
     private func orthonormalizedTangent(_ tangent: SIMD3<Float>, normal: SIMD3<Float>) -> SIMD3<Float> {
         // A degenerate triangle leaves the zero normal `flatNormals()` writes, and
-        // nothing is perpendicular to it — normalizing a fallback axis would only
-        // turn that into a NaN basis.
+        // nothing is perpendicular to it, so normalizing a fallback axis would
+        // only turn that into a NaN basis.
         guard simd_length_squared(normal) > 1e-12 else { return .zero }
         let projected = tangent - normal * simd_dot(normal, tangent)
         if simd_length_squared(projected) > 1e-12 {

--- a/Sources/VRMRealityKit/MToon/MToonConversionStyle.swift
+++ b/Sources/VRMRealityKit/MToon/MToonConversionStyle.swift
@@ -1,0 +1,38 @@
+import VRMKitRuntime
+
+/// How a standard Unlit / PBR glTF material converts into MToon when a renderer
+/// is asked to toon-shade a model that carries no MToon data of its own.
+public struct MToonConversionStyle: Sendable {
+    /// The canonical conversion style. Its MToon values come directly from the
+    /// specification defaults shared with authored MToon materials.
+    public static let defaultStyle = MToonConversionStyle(
+        shadeColorScale: 0.8,
+        shadingToonyFactor: MToonMaterialDescriptor.SpecDefault.shadingToonyFactor,
+        shadingShiftFactor: MToonMaterialDescriptor.SpecDefault.shadingShiftFactor,
+        outlineWidthFactor: MToonMaterialDescriptor.SpecDefault.outlineWidthFactor,
+        outlineColorFactor: MToonMaterialDescriptor.SpecDefault.outlineColorFactor
+    )
+
+    /// The shade color is the base color scaled by this factor per channel, so
+    /// the shadowed side keeps the material's hue.
+    public var shadeColorScale: Float
+    /// 0...1; higher values sharpen the boundary between the lit and shaded sides.
+    public var shadingToonyFactor: Float
+    /// Shifts where the lit-shade boundary sits; 0 keeps the MToon default.
+    public var shadingShiftFactor: Float
+    /// Width of the inverted-hull outline in meters; 0 draws no outline.
+    public var outlineWidthFactor: Float
+    public var outlineColorFactor: SIMD4<Float>
+
+    public init(shadeColorScale: Float = MToonConversionStyle.defaultStyle.shadeColorScale,
+                shadingToonyFactor: Float = MToonConversionStyle.defaultStyle.shadingToonyFactor,
+                shadingShiftFactor: Float = MToonConversionStyle.defaultStyle.shadingShiftFactor,
+                outlineWidthFactor: Float = MToonConversionStyle.defaultStyle.outlineWidthFactor,
+                outlineColorFactor: SIMD4<Float> = MToonConversionStyle.defaultStyle.outlineColorFactor) {
+        self.shadeColorScale = shadeColorScale
+        self.shadingToonyFactor = shadingToonyFactor
+        self.shadingShiftFactor = shadingShiftFactor
+        self.outlineWidthFactor = outlineWidthFactor
+        self.outlineColorFactor = outlineColorFactor
+    }
+}

--- a/Sources/VRMRealityKit/MToon/MToonShader.swift
+++ b/Sources/VRMRealityKit/MToon/MToonShader.swift
@@ -1,0 +1,476 @@
+#if canImport(RealityKit)
+import CoreGraphics
+import Foundation
+import Metal
+import OSLog
+import RealityKit
+import VRMKit
+import VRMKitRuntime
+
+/// Renders materials carrying MToon data, either the `VRMC_materials_mtoon`
+/// glTF extension or a VRM 0.x MToon material property, through a
+/// `CustomMaterial` toon shader with a precompiled Metal library.
+///
+/// Part of every loader's default shader chain. On platforms without
+/// `CustomMaterial` or a bundled Metal library (visionOS, Mac Catalyst) it
+/// claims no material, so the loader's built-in path renders MToon materials as
+/// Unlit approximations instead.
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+@MainActor
+public final class MToonShader: GLTFMaterialShader {
+    static let logger = Logger(subsystem: "dev.tattn.VRMKit", category: "MToon")
+    static let extensionName = "VRMC_materials_mtoon"
+
+    /// Which materials this shader renders as MToon.
+    public enum Source: Sendable {
+        /// Only materials authored as MToon, through the
+        /// `VRMC_materials_mtoon` extension or a VRM 0.x MToon material
+        /// property. The default.
+        case authoredOnly
+        /// Materials authored as MToon keep their authored values, and every
+        /// other material, PBR and Unlit alike, is converted to MToon with
+        /// the given style.
+        case convertAll(MToonConversionStyle)
+
+        /// Converts every material with the default ``MToonConversionStyle``.
+        public static var convertAll: Source { .convertAll(MToonConversionStyle()) }
+    }
+
+    /// Which materials render as MToon.
+    public let source: Source
+    /// Controls creation of MToon's inverted-hull outline pass.
+    public let isOutlineEnabled: Bool
+
+    public init(source: Source = .authoredOnly, isOutlineEnabled: Bool = true) {
+        self.source = source
+        self.isOutlineEnabled = isOutlineEnabled
+    }
+
+#if !os(visionOS)
+    /// Everything derived from one MToon material. A non-nil state is what
+    /// "this material renders as MToon" means.
+    private struct MToonState {
+        let descriptor: MToonMaterialDescriptor
+        let parameters: MToonMaterialParameters
+        let parameterTexture: CustomMaterial.Texture
+        let library: MTLLibrary
+    }
+#endif
+
+    /// `resourceName` is nil on every platform without a bundled MToon Metal
+    /// library (visionOS, Mac Catalyst), so this claims nothing there.
+    public var supportedRequiredExtensions: Set<String> {
+        MToonShaderLibraryLoader.resourceName != nil ? [Self.extensionName] : []
+    }
+
+    /// A rendering the document has ruled out, because a required extension asks
+    /// for more than this renderer draws. Unlike a build failure it never falls
+    /// through to the rest of the chain, since no other path draws it any
+    /// better, so it fails the material outright.
+    struct UnrenderableRequirement: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    public func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+#if os(visionOS)
+        return nil
+#else
+        do {
+            return try shadedMToonMaterial(for: context)
+        } catch {
+            // Two things rule the fall-through out: a document that requires
+            // `VRMC_materials_mtoon` cannot be drawn without MToon at all, and an
+            // `UnrenderableRequirement` is a rendering it has ruled out whatever
+            // draws the material next.
+            guard !isMToonRequired(by: context),
+                  !(error is UnrenderableRequirement) else { throw error }
+            logFallback(error, context: context)
+            return nil
+        }
+#endif
+    }
+
+#if !os(visionOS)
+    /// Whether the document declares itself undrawable without MToon, on a
+    /// platform this shader claims MToon on. Where it claims nothing, for want
+    /// of a bundled Metal library, the loader has already reported the required
+    /// extension, and rendering the Unlit approximation is all there is.
+    private func isMToonRequired(by context: GLTFMaterialShaderContext) -> Bool {
+        supportedRequiredExtensions.contains(Self.extensionName)
+            && context.enforcesRequiredExtension(Self.extensionName)
+    }
+
+    private func logFallback(_ error: Error, context: GLTFMaterialShaderContext) {
+        // A library failure fails every MToon material of the document alike,
+        // so it is reported once instead of per material.
+        if error is MToonShaderLibraryLoaderError {
+            context.logOnce("mtoonLibrary",
+                            "Failed to load the bundled MToon shader library, so MToon materials render as Unlit approximations: \(String(describing: error))")
+        } else {
+            Self.logger.error("Failed to build the MToon material \(context.materialIndex, privacy: .public); passing it on to the rest of the shader chain: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private func shadedMToonMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+        guard let state = try makeState(for: context) else { return nil }
+        // The rows the expression runtime animates are built right here, so the
+        // state factory only has to hand every entity graph its own copy.
+        let parameters = state.parameters
+        var shaded = GLTFShadedMaterial(material: try customMToonMaterial(state, context: context),
+                                        makeAnimatableState: { MToonAnimatableMaterialState(parameters: parameters) })
+        if isOutlineEnabled, state.descriptor.hasOutline {
+            let outline = try customMToonOutlineMaterial(state, context: context)
+            shaded.additionalPasses = [.init(material: outline, name: "outline")]
+        }
+        return shaded
+    }
+
+    private func makeState(for context: GLTFMaterialShaderContext) throws -> MToonState? {
+        guard let descriptor = try resolvedDescriptor(for: context) else { return nil }
+        let library = try MToonShaderLibraryLoader.loadDefault()
+        let textureTransform = try textureTransform(for: context, descriptor: descriptor)
+        let parameters = try parameters(for: descriptor, textureTransform: textureTransform, context: context)
+        logUnsupportedFeatures(of: descriptor, index: context.materialIndex)
+        return MToonState(descriptor: descriptor,
+                          parameters: parameters,
+                          parameterTexture: CustomMaterial.Texture(try parameters.textureResource()),
+                          library: library)
+    }
+
+    /// The MToon material model to render: the authored one when the material
+    /// carries MToon data, else, under ``Source/convertAll(_:)``, one
+    /// synthesized from its standard Unlit / PBR values.
+    ///
+    /// A material authored against an unimplemented MToon version is neither:
+    /// converting it would invent toon values over the ones it already has, so it
+    /// drops to the Unlit approximation the MToon specification names as the
+    /// fallback — unless the document requires the extension.
+    private func resolvedDescriptor(for context: GLTFMaterialShaderContext) throws -> MToonMaterialDescriptor? {
+        switch try context.mtoonResolution() {
+        case .supported(let authored):
+            return authored
+        case .unsupportedVersion(let specVersion):
+            guard !isMToonRequired(by: context) else {
+                throw UnrenderableRequirement(description: """
+                    this glTF requires \(Self.extensionName) at specVersion \(specVersion), which this \
+                    renderer does not implement
+                    """)
+            }
+            // The loader logs the version, for the built-in path too.
+            return nil
+        case .none:
+            guard case .convertAll(let style) = source else { return nil }
+            return StandardMToonConverter.migrate(material: context.material,
+                                                  vrm0Property: context.vrm0MaterialProperty,
+                                                  shadeColorScale: style.shadeColorScale,
+                                                  shadingToonyFactor: style.shadingToonyFactor,
+                                                  shadingShiftFactor: style.shadingShiftFactor,
+                                                  outlineWidthFactor: style.outlineWidthFactor,
+                                                  outlineColorFactor: style.outlineColorFactor)
+        }
+    }
+
+    private func logUnsupportedFeatures(of descriptor: MToonMaterialDescriptor, index: Int) {
+        if descriptor.renderQueueOffsetNumber != 0 {
+            Self.logger.warning("MToon material \(index, privacy: .public) requests renderQueueOffsetNumber \(descriptor.renderQueueOffsetNumber); RealityKit has no material-level draw-order hook, so it is ignored.")
+        }
+    }
+
+    private func customMToonMaterial(_ state: MToonState,
+                                     context: GLTFMaterialShaderContext) throws -> Material {
+        let mtoon = state.descriptor
+        let surface = CustomMaterial.SurfaceShader(named: "mtoonSurface", in: state.library)
+        var material = try CustomMaterial(surfaceShader: surface, lightingModel: .unlit)
+        // MToon needs more textures than CustomMaterial has semantic channels, so the
+        // extra slots ride on unrelated ones; MToon.metal reads them back the same way.
+        material.baseColor = .init(tint: .white, texture: try mtoonTexture(mtoon, slot: .base, context: context))
+        material.roughness.texture = try mtoonTexture(mtoon, slot: .shade, context: context)
+        material.specular.texture = try mtoonTexture(mtoon, slot: .shadingShift, context: context)
+        material.metallic.texture = try mtoonTexture(mtoon, slot: .matcap, context: context)
+        material.normal.texture = try mtoonTexture(mtoon, slot: .normal, context: context)
+        material.emissiveColor = .init(color: .white, texture: try mtoonTexture(mtoon, slot: .emissive, context: context))
+        material.clearcoatRoughness.texture = try mtoonTexture(mtoon, slot: .rim, context: context)
+        material.clearcoat.texture = try mtoonTexture(mtoon, slot: .outlineWidth, context: context)
+        material.ambientOcclusion.texture = try mtoonTexture(mtoon, slot: .uvAnimationMask, context: context)
+
+        applyAlphaMode(mtoon.alphaMode, alphaCutoff: mtoon.alphaCutoff, to: &material)
+        applyDepthWrite(mtoon, to: &material)
+        material.faceCulling = mtoon.cullMode.faceCulling
+        applyParameters(state, to: &material)
+        return material
+    }
+
+    private func customMToonOutlineMaterial(_ state: MToonState,
+                                            context: GLTFMaterialShaderContext) throws -> Material {
+        let mtoon = state.descriptor
+        let surface = CustomMaterial.SurfaceShader(named: "mtoonOutlineSurface", in: state.library)
+        let geometry = CustomMaterial.GeometryModifier(named: "mtoonOutlineGeometry", in: state.library)
+        var material = try CustomMaterial(surfaceShader: surface,
+                                          geometryModifier: geometry,
+                                          lightingModel: .unlit)
+        material.faceCulling = .front
+        material.baseColor = .init(tint: .white, texture: try mtoonTexture(mtoon, slot: .base, context: context))
+        material.clearcoat.texture = try mtoonTexture(mtoon, slot: .outlineWidth, context: context)
+        material.ambientOcclusion.texture = try mtoonTexture(mtoon, slot: .uvAnimationMask, context: context)
+        applyAlphaMode(mtoon.alphaMode, alphaCutoff: mtoon.alphaCutoff, to: &material)
+        applyDepthWrite(mtoon, to: &material)
+        applyParameters(state, to: &material)
+        return material
+    }
+
+    /// MToon.metal applies the UV transform from the parameter rows, so
+    /// `textureCoordinateTransform` is deliberately left at identity here.
+    private func applyParameters(_ state: MToonState, to material: inout CustomMaterial) {
+        material.custom.value = state.parameters.customValue
+        material.custom.texture = state.parameterTexture
+    }
+
+    private func applyAlphaMode(_ mode: GLTF.Material.AlphaMode,
+                                alphaCutoff: Float,
+                                to material: inout CustomMaterial) {
+        let settings = GLTFAlphaModeSettings(mode, alphaCutoff: alphaCutoff)
+        material.blending = settings.isTransparent ? .transparent(opacity: .init(scale: 1.0)) : .opaque
+        material.opacityThreshold = settings.opacityThreshold
+    }
+
+    /// MToon's `transparentWithZWrite` asks a blended material to still write depth.
+    private func applyDepthWrite(_ mtoon: MToonMaterialDescriptor, to material: inout CustomMaterial) {
+        material.writesDepth = mtoon.alphaMode != .BLEND || mtoon.transparentWithZWrite
+    }
+
+    /// The descriptor's texture for `slot`, or the slot's neutral fallback.
+    private func mtoonTexture(_ descriptor: MToonMaterialDescriptor,
+                              slot: MToonTextureSlot,
+                              context: GLTFMaterialShaderContext) throws -> CustomMaterial.Texture {
+        guard let texture = descriptor.texture(for: slot) else {
+            return CustomMaterial.Texture(try fallbackTextureResource(slot.fallback))
+        }
+        return CustomMaterial.Texture(try context.texture(withTextureIndex: texture.index, semantic: slot.semantic))
+    }
+
+    private func parameters(for descriptor: MToonMaterialDescriptor,
+                            textureTransform: MaterialParameterTypes.TextureCoordinateTransform,
+                            context: GLTFMaterialShaderContext) throws -> MToonMaterialParameters {
+        var parameters = MToonMaterialParameters(descriptor)
+        parameters.setTextureTransform(scale: textureTransform.scale,
+                                       offset: textureTransform.offset,
+                                       rotation: textureTransform.rotation)
+        for slot in MToonTextureSlot.allCases {
+            try parameters.setSampler(samplerParameters(for: descriptor.texture(for: slot), context: context),
+                                      for: slot)
+        }
+        return parameters
+    }
+
+    /// MToon.metal transforms in glTF UV space, so unlike the standard path the
+    /// transform passes through unconverted.
+    private func textureTransform(for context: GLTFMaterialShaderContext,
+                                  descriptor: MToonMaterialDescriptor) throws -> MaterialParameterTypes.TextureCoordinateTransform {
+        let textures = descriptor.uvAccessedTextures
+        try validateTextureTransformsAreRenderable(textures, context: context)
+        let selectedTexCoord = context.selectedTexCoord
+        if textures.contains(where: { $0.texCoord != selectedTexCoord }) {
+            context.logOnce("mtoonTexCoord-\(context.materialIndex)", """
+                MToon material \(context.materialIndex) samples several UV sets; RealityKit meshes carry \
+                one UV channel, so every MToon texture is sampled with UV set \(selectedTexCoord).
+                """)
+        }
+        let selected = context.selectedUVTransform(for: textures)
+        return MaterialParameterTypes.TextureCoordinateTransform(offset: selected.offset,
+                                                                 scale: selected.scale,
+                                                                 rotation: selected.rotation)
+    }
+
+    /// RealityKit gives a material one UV transform, and its mesh one UV set, so
+    /// MToon draws all of its textures through the first UV-accessed texture's
+    /// `KHR_texture_transform`, on the UV set the core material selected.
+    ///
+    /// The loader checks the same limit over the core glTF material; this covers
+    /// the textures only MToon names (the shade, shading-shift, rim, outline
+    /// width and UV-animation mask maps), which the loader never sees. A document
+    /// that merely *uses* the extension renders through the approximation and
+    /// logs it; one that *requires* it is asking for a result no path of this
+    /// renderer draws, so the material fails instead.
+    private func validateTextureTransformsAreRenderable(_ textures: [MToonMaterialDescriptor.Texture],
+                                                        context: GLTFMaterialShaderContext) throws {
+        guard context.enforcesRequiredExtension("KHR_texture_transform") else { return }
+        let index = context.materialIndex
+        let selectedTexCoord = context.selectedTexCoord
+        guard textures.allSatisfy({ $0.texCoord == selectedTexCoord }) else {
+            throw UnrenderableRequirement(description: """
+                this glTF requires KHR_texture_transform, and MToon material \(index) samples UV sets \
+                other than \(selectedTexCoord), which this renderer cannot draw
+                """)
+        }
+        let transforms = textures.map { $0.transform ?? GLTFUVTransform() }
+        guard transforms.allSatisfy({ $0 == transforms.first }) else {
+            throw UnrenderableRequirement(description: """
+                this glTF requires KHR_texture_transform, and MToon material \(index) gives its textures \
+                different transforms, which this renderer cannot draw
+                """)
+        }
+    }
+
+    private func samplerParameters(for texture: MToonMaterialDescriptor.Texture?,
+                                   context: GLTFMaterialShaderContext) throws -> SIMD4<Float> {
+        guard let texture,
+              let sampler = try context.gltfSampler(withTextureIndex: texture.index) else {
+            return MToonMaterialParameters.defaultSampler
+        }
+        return samplerParameters(sampler)
+    }
+
+    /// (wrapS, wrapT, filterIndex, 0), the sampler row layout `MToon.metal` expects.
+    private func samplerParameters(_ sampler: GLTF.Sampler) -> SIMD4<Float> {
+        let (minFilter, mipFilter) = (sampler.minFilter ?? .LINEAR_MIPMAP_LINEAR).metalFilters
+        let filter = MToonSamplerFilter(
+            magnification: (sampler.magFilter ?? .LINEAR).metalFilter == .nearest ? .nearest : .linear,
+            minification: minFilter == .nearest ? .nearest : .linear,
+            mip: MToonSamplerFilter.MipFilter(mipFilter)
+        )
+        return SIMD4<Float>(wrapMode(sampler.wrapS),
+                            wrapMode(sampler.wrapT),
+                            Float(filter.index),
+                            0)
+    }
+
+    private func wrapMode(_ wrap: GLTF.Sampler.Wrap) -> Float {
+        switch wrap {
+        case .REPEAT: return 0
+        case .CLAMP_TO_EDGE: return 1
+        case .MIRRORED_REPEAT: return 2
+        }
+    }
+
+    private var fallbackTextureCache: [MToonTextureSlot.Fallback: TextureResource] = [:]
+
+    /// The neutral 1x1 texture bound when a material omits an MToon slot.
+    private func fallbackTextureResource(_ fallback: MToonTextureSlot.Fallback) throws -> TextureResource {
+        if let cached = fallbackTextureCache[fallback] {
+            return cached
+        }
+        let texture: TextureResource
+        switch fallback {
+        case .white:
+            texture = try solidColorTextureResource(rgba: [255, 255, 255, 255], semantic: .color)
+        case .neutralNormal:
+            texture = try solidColorTextureResource(rgba: [128, 128, 255, 255], semantic: .normal)
+        }
+        fallbackTextureCache[fallback] = texture
+        return texture
+    }
+
+    private func solidColorTextureResource(rgba: [UInt8],
+                                           semantic: TextureResource.Semantic) throws -> TextureResource {
+        guard let provider = CGDataProvider(data: Data(rgba) as CFData),
+              let image = CGImage(width: 1,
+                                  height: 1,
+                                  bitsPerComponent: 8,
+                                  bitsPerPixel: 32,
+                                  bytesPerRow: 4,
+                                  space: CGColorSpaceCreateDeviceRGB(),
+                                  bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+                                  provider: provider,
+                                  decode: nil,
+                                  shouldInterpolate: false,
+                                  intent: .defaultIntent) else {
+            throw VRMError._dataInconsistent("failed to create 1x1 \(semantic) texture")
+        }
+        return try TextureResource(image: image, options: .init(semantic: semantic))
+    }
+#endif
+}
+
+/// The mutable MToon parameter rows of one material, held per loaded entity so
+/// expression changes on one entity never reach another.
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+@MainActor
+final class MToonAnimatableMaterialState: VRMAnimatableMaterialState {
+    private(set) var parameters: MToonMaterialParameters
+#if !os(visionOS)
+    /// The last texture ``prepareFlush()`` baked, pre-wrapped so applying it to
+    /// several materials shares one wrapper. Until the first flush the material
+    /// keeps the parameter texture it was built with.
+    private var bakedTexture: CustomMaterial.Texture?
+#endif
+
+    init(parameters: MToonMaterialParameters) {
+        self.parameters = parameters
+    }
+
+    // MToon has a row for every bindable value, so it claims all of them.
+
+    func color(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float>? {
+        parameters.color(for: type)
+    }
+
+    func setColor(_ color: SIMD4<Float>,
+                  for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> Bool {
+        parameters.setColor(color, for: type)
+        return true
+    }
+
+    var textureTransform: MaterialParameterTypes.TextureCoordinateTransform? {
+        parameters.textureTransform
+    }
+
+    func setTextureTransform(scale: SIMD2<Float>, offset: SIMD2<Float>, rotation: Float) -> Bool {
+        parameters.setTextureTransform(scale: scale, offset: offset, rotation: rotation)
+        return true
+    }
+
+    /// The light direction rides in `custom.value` rather than in a parameter
+    /// row, so it reaches the materials through ``apply(to:)`` alone, without
+    /// rebuilding the packed texture, and without clearing a rebuild an earlier
+    /// row change is still waiting for.
+    func setLightDirection(_ direction: SIMD3<Float>) {
+        parameters.lightDirection = direction
+    }
+
+    func setLighting(color: SIMD3<Float>, ambient: SIMD3<Float>) {
+        parameters.lightColor = SIMD4<Float>(color, 1)
+        parameters.ambientColor = SIMD4<Float>(ambient, 1)
+    }
+
+    func prepareFlush() -> Bool {
+#if os(visionOS)
+        return true
+#else
+        do {
+            bakedTexture = CustomMaterial.Texture(try parameters.textureResource())
+            return true
+        } catch {
+            MToonShader.logger.error("Failed to update MToon parameter texture: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+#endif
+    }
+
+    func apply(to material: any Material) -> any Material {
+#if os(visionOS)
+        return material
+#else
+        guard var material = material as? CustomMaterial else { return material }
+        material.custom.value = parameters.customValue
+        if let bakedTexture {
+            material.custom.texture = bakedTexture
+        }
+        return material
+#endif
+    }
+
+    /// The light direction rides in `custom.value` alone, so this pushes it
+    /// without touching the parameter texture. That is cheap enough for
+    /// per-frame light tracking, and it cannot clear a rebuild an earlier row
+    /// change is still waiting for.
+    func applyLightDirection(to material: any Material) -> any Material {
+#if os(visionOS)
+        return material
+#else
+        guard var material = material as? CustomMaterial else { return material }
+        material.custom.value = parameters.customValue
+        return material
+#endif
+    }
+}
+#endif

--- a/Sources/VRMRealityKit/Materials/GLTFMaterialShader.swift
+++ b/Sources/VRMRealityKit/Materials/GLTFMaterialShader.swift
@@ -1,0 +1,240 @@
+#if canImport(RealityKit)
+import RealityKit
+import VRMKit
+import VRMKitRuntime
+
+/// One way of drawing glTF materials.
+///
+/// A loader consults its shader chain in order and renders each material with
+/// the first shader that returns a non-nil ``GLTFShadedMaterial``. Materials no
+/// shader claims render through the loader's built-in Unlit / PBR path, which
+/// implements the glTF core specification and cannot be removed.
+///
+/// A shader replaces material *construction* only. The mesh it draws is the one
+/// the loader builds from the core glTF material: that material's textures
+/// decide which UV set the mesh carries, and its normal texture decides whether
+/// tangents are generated. A shader cannot ask for vertex data the core material
+/// does not, so it renders within those inputs.
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+@MainActor
+public protocol GLTFMaterialShader: AnyObject {
+    /// The materials this shader builds for the context's material, or nil to
+    /// pass it on to the next shader in the chain (and ultimately the built-in
+    /// Unlit / PBR path).
+    ///
+    /// A thrown error fails the material instead of falling through: the
+    /// generic glTF load rethrows it, while a VRM load falls back to the
+    /// default material. A shader that can degrade gracefully, the way MToon
+    /// falls back to Unlit, should catch its own errors and return nil, unless
+    /// the document lists its extension in `extensionsRequired`: rendering
+    /// without it is then not a degradation the document allows.
+    func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial?
+
+    /// glTF extensions this shader implements, merged into the loader's
+    /// `extensionsRequired` validation. Defaults to none.
+    ///
+    /// Only claim an extension this shader can draw from the material alone:
+    /// the mesh inputs are fixed, as described above.
+    var supportedRequiredExtensions: Set<String> { get }
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+public extension GLTFMaterialShader {
+    var supportedRequiredExtensions: Set<String> { [] }
+}
+
+/// What one glTF material renders as: the material itself, plus any additional
+/// render passes drawn as sibling model entities of the same mesh.
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+public struct GLTFShadedMaterial {
+    /// One extra render pass of a shaded material, drawn by a sibling model
+    /// entity sharing the mesh, such as MToon's inverted-hull outline.
+    public struct Pass {
+        public var material: any Material
+        /// Appended to the mesh's name to name the pass entity: "outline" of the
+        /// mesh "mesh_0" is drawn by "mesh_0_outline".
+        public var name: String
+
+        public init(material: any Material, name: String) {
+            self.material = material
+            self.name = name
+        }
+    }
+
+    public var material: any Material
+    /// Extra passes, added to the scene before the main model entity.
+    public var additionalPasses: [Pass]
+    /// Makes a fresh ``VRMAnimatableMaterialState`` for this material, letting
+    /// VRM expressions (`materialColorBind` / `textureTransformBind`) drive it
+    /// the way MToon does. Every loaded entity graph calls it once per material,
+    /// so animating one entity never affects another.
+    ///
+    /// Leaving it nil is fine, and so is a state claiming only some values:
+    /// everything unclaimed falls back to mutating the RealityKit material
+    /// properties directly, which only reaches the standard material types.
+    public var makeAnimatableState: (@MainActor () -> any VRMAnimatableMaterialState)?
+
+    public init(material: any Material,
+                additionalPasses: [Pass] = [],
+                makeAnimatableState: (@MainActor () -> any VRMAnimatableMaterialState)? = nil) {
+        self.material = material
+        self.additionalPasses = additionalPasses
+        self.makeAnimatableState = makeAnimatableState
+    }
+}
+
+/// One material of the document being loaded, plus the loader services a shader
+/// builds it from. Only valid during the call it is passed to.
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+@MainActor
+public struct GLTFMaterialShaderContext {
+    /// The loader building the material. The service methods below go through
+    /// its caches, so shaders share decoded textures with the built-in paths.
+    let loader: GLTFEntityLoader
+    /// Index of ``material`` in the document's `materials`.
+    public let materialIndex: Int
+    /// The glTF material to build.
+    public let material: GLTF.Material
+    /// The VRM 0.x Unity material property describing ``material``, when the
+    /// document is a VRM 0.x model.
+    ///
+    /// Not public: a VRM 0.x material model hanging off a generic glTF context
+    /// couples the two. It can be opened up once a shader outside this module
+    /// needs it; the reverse is not a change that can be made.
+    let vrm0MaterialProperty: VRM0.MaterialProperty?
+
+    /// The document being loaded, the escape hatch for anything the services
+    /// below do not cover.
+    public var document: GLTFDocument { loader.document }
+
+    /// Whether the document declares itself undrawable without `name` *and* this
+    /// load honors that declaration.
+    ///
+    /// A shader that degrades gracefully should still throw while this is true:
+    /// rendering the approximation is not a degradation the document allows. VRM
+    /// loads answer false even for a listed extension, because a VRM renders with
+    /// whatever this renderer can build.
+    public func enforcesRequiredExtension(_ name: String) -> Bool {
+        loader.enforcesRequiredExtension(name)
+    }
+
+    /// The UV set the meshes rendering this material carry, decided by the core
+    /// glTF material's textures. A shader sampling any other set renders through
+    /// this one, since the mesh carries no second UV channel to sample.
+    public var selectedTexCoord: Int {
+        loader.selectedTexCoord(withMaterialIndex: materialIndex)
+    }
+
+    /// The material the loader's built-in Unlit / PBR path would build.
+    ///
+    /// A shader that only wants to adjust the standard result can build on this
+    /// instead of reimplementing the whole path.
+    public func standardMaterial() throws -> any Material {
+        try loader.standardMaterial(for: self)
+    }
+
+    /// The glTF sampler the texture at `index` references, or nil when it uses
+    /// the defaults.
+    ///
+    /// Not public: the raw glTF record, of use only to a shader packing its own
+    /// sampler state the way MToon does. Assigning a texture to a material
+    /// parameter wants ``materialTexture(withTextureIndex:semantic:)`` instead.
+    func gltfSampler(withTextureIndex index: Int) throws -> GLTF.Sampler? {
+        try loader.gltfSampler(withTextureIndex: index)
+    }
+
+    /// Logs a limitation warning once per loader, deduplicated by `key`.
+    /// The message is only built the first time.
+    public func logOnce(_ key: String, _ message: @autoclosure () -> String) {
+        loader.logOnce(key, message())
+    }
+
+    /// What MToon data ``material`` carries, from the `VRMC_materials_mtoon`
+    /// extension or the VRM 0.x property, decoded and cached by the loader.
+    func mtoonResolution() throws -> MToonMaterialDescriptor.Resolution {
+        try loader.mtoonResolution(withMaterialIndex: materialIndex)
+    }
+
+    /// The single UV transform this renderer applies for `textures`. The first
+    /// UV-accessed texture's wins, logging once when they disagree.
+    func selectedUVTransform(for textures: [GLTFSampledTexture]) -> GLTFUVTransform {
+        loader.selectedUVTransform(withMaterialIndex: materialIndex, textures: textures)
+    }
+
+    /// The decoded texture at `index`, cached per (index, semantic).
+    public func texture(withTextureIndex index: Int,
+                        semantic: TextureResource.Semantic = .color) throws -> TextureResource {
+        try loader.texture(withTextureIndex: index, semantic: semantic)
+    }
+
+    /// The RealityKit sampler for the glTF texture at `index`.
+    ///
+    /// Not public: ``materialTexture(withTextureIndex:semantic:)`` pairs it with
+    /// its texture in one step, which is all a material parameter takes.
+    func textureSampler(withTextureIndex index: Int) throws -> MaterialParameters.Texture.Sampler {
+        try loader.sampler(withTextureIndex: index)
+    }
+
+    /// The texture at `index` paired with its sampler, ready to assign to a
+    /// material parameter.
+    public func materialTexture(withTextureIndex index: Int,
+                                semantic: TextureResource.Semantic = .color) throws -> MaterialParameters.Texture {
+        try loader.materialTexture(withTextureIndex: index, semantic: semantic)
+    }
+}
+
+/// The mutable render parameters of one material, as the VRM expression
+/// runtime drives them.
+///
+/// Writes accumulate in the state; the runtime then calls ``prepareFlush()``
+/// once and ``apply(to:)`` for every material instance rendering the same glTF
+/// material (including additional passes such as outlines).
+///
+/// A state claims values one at a time: it answers nil / false for a value it
+/// does not animate, and the runtime then drives that value through the
+/// RealityKit material properties, as it does for a material with no state at
+/// all. The defaults below claim nothing, so a state only implements what it
+/// animates and the rest keeps working.
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+@MainActor
+public protocol VRMAnimatableMaterialState: AnyObject {
+    /// The current value of one bindable color, or nil for a color this state
+    /// does not animate. Defaults to nil.
+    func color(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float>?
+    /// Records a `materialColorBind` write, answering whether this state
+    /// animates that color. Defaults to false.
+    func setColor(_ color: SIMD4<Float>,
+                  for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> Bool
+    /// The UV transform the material currently renders with, or nil for a state
+    /// that does not animate one. Defaults to nil.
+    var textureTransform: MaterialParameterTypes.TextureCoordinateTransform? { get }
+    /// Records a `textureTransformBind` write, answering whether this state
+    /// animates the UV transform. Defaults to false.
+    func setTextureTransform(scale: SIMD2<Float>, offset: SIMD2<Float>, rotation: Float) -> Bool
+    /// Bakes pending writes into whatever ``apply(to:)`` pushes. Returning
+    /// false keeps the state dirty, and the runtime retries on its next flush.
+    /// Defaults to true, for a state ``apply(to:)`` reads directly.
+    func prepareFlush() -> Bool
+    /// The material updated to this state, or the material unchanged when it is
+    /// not one this state describes.
+    func apply(to material: any Material) -> any Material
+}
+
+@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+public extension VRMAnimatableMaterialState {
+    func color(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float>? {
+        nil
+    }
+
+    func setColor(_ color: SIMD4<Float>,
+                  for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> Bool {
+        false
+    }
+
+    var textureTransform: MaterialParameterTypes.TextureCoordinateTransform? { nil }
+
+    func setTextureTransform(scale: SIMD2<Float>, offset: SIMD2<Float>, rotation: Float) -> Bool { false }
+
+    func prepareFlush() -> Bool { true }
+}
+#endif

--- a/Sources/VRMRealityKit/Shaders/MToon.metal
+++ b/Sources/VRMRealityKit/Shaders/MToon.metal
@@ -147,7 +147,7 @@ half4 mtoonFilteredSample(texture2d<half> texture,
 
 // The sampler parameter row is (wrapS, wrapT, filterIndex, 0). The wrap modes
 // are encoded as 0 = repeat, 1 = clamp to edge, 2 = mirrored repeat by
-// VRMEntityLoader.mtoonWrapMode(_:), and filterIndex by MToonSamplerFilter.
+// MToonShader.wrapMode(_:), and filterIndex by MToonSamplerFilter.
 #define MTOON_SAMPLE_CASE(name, index)                                               \
     case (index): return mtoonFilteredSample<ImplicitLOD>(texture, name, uv, filterIndex);
 
@@ -232,7 +232,7 @@ float3 realityKitApproximateOutlineLighting(float3 lightColor, float outlineLigh
     return mix(float3(1.0), lightColor, saturate(outlineLightingMix));
 }
 
-// Converts RealityKit's mesh UV (v pointing up, as VRMEntityLoader writes it)
+// Converts RealityKit's mesh UV (v pointing up, as GLTFEntityLoader writes it)
 // into the glTF / MToon UV space that KHR_texture_transform, MToon UV animation
 // and Metal texture sampling all share (v pointing down).
 //

--- a/Sources/VRMRealityKit/Shaders/MToonCore.h
+++ b/Sources/VRMRealityKit/Shaders/MToonCore.h
@@ -39,7 +39,7 @@ inline float3 mtoonIndirectLighting(float3 litColor, float3 giColor)
 // Matcap UV, in the specification's UV convention (v pointing up).
 //
 // The basis is built from the view direction rather than from a view matrix, so
-// `normal` and `viewDirection` only have to agree with each other — both are
+// `normal` and `viewDirection` only have to agree with each other. Both are
 // world-space here, the same space the rim and shading terms use.
 // https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0#matcap
 inline metal::float2 mtoonMatcapUV(float3 normal, float3 viewDirection)

--- a/Sources/VRMRealityKit/Shaders/MToonMetallibInputs.txt
+++ b/Sources/VRMRealityKit/Shaders/MToonMetallibInputs.txt
@@ -3,6 +3,6 @@ flags=-Wall -Wextra -Werror
 target=macosx|macos-|-mmacosx-version-min=12.0|MToon-macos.metallib
 target=iphoneos|ios-|-mios-version-min=15.0|MToon-ios.metallib
 target=iphonesimulator|ios-|-miphonesimulator-version-min=15.0|MToon-iossim.metallib
-fe9fe1508ea72c766b169f7fa1318840b7b48d1de0f6065b2c16e1ad0665089c  Sources/VRMRealityKit/Shaders/MToonCore.h
-bc474b74ef0b2f812ec1e9c4120916531b92065a963bc1cf46e629c0cd7b28d5  Sources/VRMRealityKit/Shaders/MToon.metal
+0888beed6a177134d0033b0a6f53424d087360b2c58f8e0bc160b44e0c3cb512  Sources/VRMRealityKit/Shaders/MToonCore.h
+952ee66054aa4002ea4e0ced7f36c848a4ea840ece404439a74ee5eceee452f5  Sources/VRMRealityKit/Shaders/MToon.metal
 83dc27b262e43b5c83b6ee8b4c8b5702acc533eb3a7deda108ac548786d7bce9  scripts/build-mtoon-metallibs.sh

--- a/Sources/VRMRealityKit/VRMEntityLoader.swift
+++ b/Sources/VRMRealityKit/VRMEntityLoader.swift
@@ -16,12 +16,10 @@ public class VRMEntityLoader: GLTFEntityLoader {
 
     public init(vrm: VRM,
                 rootDirectory: URL? = nil,
-                isMToonEnabled: Bool = true,
-                isOutlineEnabled: Bool = true) {
+                shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) {
         self.vrm = vrm
         super.init(document: GLTFDocument(binary: vrm.gltf, rootDirectory: rootDirectory),
-                   isMToonEnabled: isMToonEnabled,
-                   isOutlineEnabled: isOutlineEnabled)
+                   shaders: shaders)
         entityName = vrm.meta.title
     }
 
@@ -30,41 +28,31 @@ public class VRMEntityLoader: GLTFEntityLoader {
     /// - Parameters:
     ///   - url: VRM file location.
     ///   - rootDirectory: Optional base directory for external glTF resources.
-    ///   - isMToonEnabled: When `false`, MToon is fully disabled and Unlit / PBR fallbacks are used.
-    ///   - isOutlineEnabled: Controls creation of MToon outline entities.
+    ///   - shaders: The material shader chain; see ``GLTFMaterialShader``.
     public convenience init(withURL url: URL,
                             rootDirectory: URL? = nil,
-                            isMToonEnabled: Bool = true,
-                            isOutlineEnabled: Bool = true) throws {
-        let vrm = try VRMLoader().load(withURL: url)
-        self.init(vrm: vrm,
+                            shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) throws {
+        self.init(vrm: try VRMLoader().load(withURL: url),
                   rootDirectory: rootDirectory,
-                  isMToonEnabled: isMToonEnabled,
-                  isOutlineEnabled: isOutlineEnabled)
+                  shaders: shaders)
     }
 
     /// Loads a bundled VRM resource.
     public convenience init(named: String,
                             rootDirectory: URL? = nil,
-                            isMToonEnabled: Bool = true,
-                            isOutlineEnabled: Bool = true) throws {
-        let vrm = try VRMLoader().load(named: named)
-        self.init(vrm: vrm,
+                            shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) throws {
+        self.init(vrm: try VRMLoader().load(named: named),
                   rootDirectory: rootDirectory,
-                  isMToonEnabled: isMToonEnabled,
-                  isOutlineEnabled: isOutlineEnabled)
+                  shaders: shaders)
     }
 
     /// Loads a VRM from in-memory data.
     public convenience init(withData data: Data,
                             rootDirectory: URL? = nil,
-                            isMToonEnabled: Bool = true,
-                            isOutlineEnabled: Bool = true) throws {
-        let vrm = try VRMLoader().load(withData: data)
-        self.init(vrm: vrm,
+                            shaders: [any GLTFMaterialShader] = GLTFEntityLoader.defaultShaders) throws {
+        self.init(vrm: try VRMLoader().load(withData: data),
                   rootDirectory: rootDirectory,
-                  isMToonEnabled: isMToonEnabled,
-                  isOutlineEnabled: isOutlineEnabled)
+                  shaders: shaders)
     }
 
     /// Unlike the generic loader, a VRM without a default scene still loads: a
@@ -110,6 +98,12 @@ public class VRMEntityLoader: GLTFEntityLoader {
         }
     }
 
+    /// A VRM renders with whatever this renderer can build, so `extensionsRequired`
+    /// never fails one of its materials either: a shader that would refuse to
+    /// approximate draws its approximation here instead of dropping the material
+    /// to the default one.
+    override func enforcesRequiredExtension(_ name: String) -> Bool { false }
+
     /// Some VRM meshes split primitives by indices but share the same POSITION
     /// accessor, and only one of them carries the morph targets. SceneKit reuses
     /// the morpher across such primitives, so mimic that by sharing the targets.
@@ -138,32 +132,18 @@ public class VRMEntityLoader: GLTFEntityLoader {
 
     /// Unlike the generic loader, a VRM whose material this renderer cannot build
     /// still renders, with the default material in its place.
-    override func primitiveMaterial(withMaterialIndex index: Int) throws -> Material {
+    ///
+    /// The fallback is cached like any other resolved material, so the failed
+    /// build is not retried and the runtime state comes from what is drawn.
+    override func primitiveShadedMaterial(withMaterialIndex index: Int) throws -> GLTFShadedMaterial {
         do {
-            return try super.primitiveMaterial(withMaterialIndex: index)
+            return try super.primitiveShadedMaterial(withMaterialIndex: index)
         } catch {
             Self.gltfLogger.error("Failed to build the material \(index, privacy: .public); falling back to the default material: \(String(describing: error), privacy: .public)")
-            return defaultMaterial()
+            let shaded = GLTFShadedMaterial(material: defaultMaterial())
+            cacheShadedMaterial(shaded, withMaterialIndex: index)
+            return shaded
         }
-    }
-
-    /// The color a `materialColorBind` starts from. MToon keeps it in its
-    /// parameter rows, everything else in the RealityKit material.
-    func currentMaterialColor(withMaterialIndex index: Int,
-                              type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) throws -> SIMD4<Float> {
-        if let color = try mtoonParameters(withMaterialIndex: index)?.color(for: type) {
-            return color
-        }
-        return try material(withMaterialIndex: index).currentColor(for: type)
-    }
-
-    /// The UV transform a `textureTransformBind` starts from. MToon keeps it in
-    /// its parameter rows, everything else in the RealityKit material.
-    func currentTextureTransform(withMaterialIndex index: Int) throws -> MaterialParameterTypes.TextureCoordinateTransform {
-        if let transform = try mtoonParameters(withMaterialIndex: index)?.textureTransform {
-            return transform
-        }
-        return try material(withMaterialIndex: index).currentTextureTransform
     }
 
     override func vrm0MaterialProperty(for gltfMaterial: GLTF.Material) -> VRM0.MaterialProperty? {

--- a/Tests/Assets/GLTF/README.md
+++ b/Tests/Assets/GLTF/README.md
@@ -6,7 +6,7 @@ Test fixtures for the generic glTF rendering path, taken from
 
 **Every model here is licensed CC0-1.0**, so the fixtures carry no attribution
 obligation. Models under CC-BY-4.0 were deliberately excluded to keep this
-repository free of attribution requirements — cover their features with
+repository free of attribution requirements; cover their features with
 hand-written fixtures instead (sparse accessors are covered that way in
 `GLTFEntityLoaderTests.testSparseAccessorSubstitutesPositions`). Each model keeps
 its upstream `LICENSE.md`; note that those metadocumentation files are

--- a/Tests/Assets/README.md
+++ b/Tests/Assets/README.md
@@ -10,7 +10,7 @@ Fixtures shared by every test target, and by the Example apps.
 `VRMTestSupport` owns this directory as its resources (see `Package.swift`), so
 the fixtures are copied into one bundle instead of one per test target. Reach
 them through `GLTFSampleAsset` / `VRMSampleAsset`, never through
-`Bundle.module` of a test target — the assets are not in those bundles.
+`Bundle.module` of a test target: the assets are not in those bundles.
 
 When adding a fixture, drop it in the matching directory and add a case to the
 corresponding enum in `Tests/VRMTestSupport`.

--- a/Tests/VRMKitTests/GLTFSampleAssetTests.swift
+++ b/Tests/VRMKitTests/GLTFSampleAssetTests.swift
@@ -3,8 +3,8 @@ import Testing
 import VRMTestSupport
 @testable import VRMKit
 
-/// Parses the Khronos CC0 sample assets, covering what the VRM fixtures — all
-/// GLB with an embedded BIN chunk — never reach: JSON `.gltf` files with
+/// Parses the Khronos CC0 sample assets, covering what the VRM fixtures, all
+/// GLB with an embedded BIN chunk, never reach: JSON `.gltf` files with
 /// external resources and with data URI buffers.
 @Suite
 struct GLTFSampleAssetTests {

--- a/Tests/VRMRealityKitTests/GLTFAnimationPlaybackTests.swift
+++ b/Tests/VRMRealityKitTests/GLTFAnimationPlaybackTests.swift
@@ -435,7 +435,7 @@ struct GLTFAnimationPlaybackTests {
     }
 
     /// One accessor of a hand-written animation sampler, described exactly as it
-    /// should reach the loader — storage the spec forbids included.
+    /// should reach the loader, storage the spec forbids included.
     private struct SamplerStorage {
         let componentType: Int
         let type: String

--- a/Tests/VRMRealityKitTests/GLTFEntityLoaderTests.swift
+++ b/Tests/VRMRealityKitTests/GLTFEntityLoaderTests.swift
@@ -443,6 +443,31 @@ struct GLTFEntityLoaderTests {
         #expect(throws: VRMError.self) { try loader(emissiveScale: [3.0, 3.0]).loadEntity() }
     }
 
+    /// `KHR_texture_transform` overrides the UV set a texture samples, and a mesh
+    /// carries one UV channel, so an asset that *requires* the extension while
+    /// pointing a material's textures at different sets is asking for a render
+    /// this loader cannot produce, however its transforms agree.
+    @Test
+    func testRequiredTextureTransformBeyondOneUVSetPerMaterialFailsTheLoad() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        func loader(emissiveTexCoord: Int) throws -> GLTFEntityLoader {
+            try TestSupport.loader(.simpleTexture) { json in
+                let texture: (Int) -> [String: Any] = { texCoord in
+                    ["index": 0, "extensions": ["KHR_texture_transform": ["texCoord": texCoord]]]
+                }
+                json["extensionsUsed"] = ["KHR_texture_transform"]
+                json["extensionsRequired"] = ["KHR_texture_transform"]
+                json["materials"] = [[
+                    "pbrMetallicRoughness": ["baseColorTexture": texture(0)],
+                    "emissiveTexture": texture(emissiveTexCoord)
+                ]]
+            }
+        }
+
+        _ = try loader(emissiveTexCoord: 0).loadEntity()
+        #expect(throws: VRMError.self) { try loader(emissiveTexCoord: 1).loadEntity() }
+    }
+
     /// Skin joints index the joint arrays positionally, so a repeated, missing or
     /// out-of-range joint has to throw rather than trap.
     @Test
@@ -701,7 +726,7 @@ struct GLTFEntityLoaderTests {
             json["nodes"] = nodes
         }
 
-        let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
         let clip = try #require(vrmEntity.blendShapeClips.values.first { clip in
             clip.values.contains { $0.weight > 0 }
         })

--- a/Tests/VRMRealityKitTests/GLTFSampleAssetRenderingTests.swift
+++ b/Tests/VRMRealityKitTests/GLTFSampleAssetRenderingTests.swift
@@ -154,7 +154,7 @@ struct GLTFSampleAssetRenderingTests {
     }
 
     /// glTF puts no restriction on where a skinned mesh sits, so it may hang
-    /// below one of its own joints — a joint whose entity is then asked for while
+    /// below one of its own joints, a joint whose entity is then asked for while
     /// its own node is still under construction.
     @Test
     func testSkinnedMeshBelowOneOfItsJointsResolvesToTheSameJointEntities() throws {

--- a/Tests/VRMRealityKitTests/MaterialShaderChainTests.swift
+++ b/Tests/VRMRealityKitTests/MaterialShaderChainTests.swift
@@ -1,0 +1,497 @@
+#if canImport(RealityKit)
+import Foundation
+import RealityKit
+import Testing
+import VRMKit
+import VRMTestSupport
+@testable import VRMRealityKit
+
+/// The shader-chain seam of the loaders: custom `GLTFMaterialShader`s take over
+/// material building, and `MToonShader(source: .convertAll)` toon-shades plain
+/// glTF assets that carry no MToon data.
+@Suite
+@MainActor
+struct MaterialShaderChainTests {
+
+    /// A chain-less loader renders everything through the built-in Unlit / PBR
+    /// path.
+    @Test
+    func testEmptyShaderChainRendersStandardMaterials() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let loader = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url, shaders: [])
+        #expect(try loader.material(withMaterialIndex: 0) is PhysicallyBasedMaterial)
+    }
+
+    /// The first shader returning a material wins; later shaders and the
+    /// built-in path never see the material.
+    @Test
+    func testCustomShaderTakesOverMaterialBuilding() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        final class SolidColorShader: GLTFMaterialShader {
+            private(set) var seenMaterialIndices: [Int] = []
+
+            func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+                seenMaterialIndices.append(context.materialIndex)
+                var material = UnlitMaterial(applyPostProcessToneMap: false)
+                material.color = .init(tint: .magenta)
+                return GLTFShadedMaterial(material: material)
+            }
+        }
+
+        let shader = SolidColorShader()
+        let loader = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url, shaders: [shader])
+        let entity = try loader.loadEntity()
+
+        #expect(shader.seenMaterialIndices == [0])
+        for modelEntity in entity.modelEntitiesInHierarchy {
+            let materials = modelEntity.components[ModelComponent.self]?.materials ?? []
+            #expect(materials.allSatisfy { $0 is UnlitMaterial })
+        }
+    }
+
+    /// A shader that passes (returns nil) falls through to the built-in path.
+    @Test
+    func testDecliningShaderFallsThroughToTheStandardPath() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        final class DecliningShader: GLTFMaterialShader {
+            func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+                nil
+            }
+        }
+
+        let loader = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url,
+                                          shaders: [DecliningShader()])
+        #expect(try loader.material(withMaterialIndex: 0) is PhysicallyBasedMaterial)
+    }
+
+    /// A custom shader's extra passes become sibling model entities, the way
+    /// MToon outlines do.
+    @Test
+    func testAdditionalPassesBecomeSiblingModelEntities() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        final class TwoPassShader: GLTFMaterialShader {
+            func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+                GLTFShadedMaterial(material: UnlitMaterial(),
+                                   additionalPasses: [.init(material: UnlitMaterial(), name: "halo")])
+            }
+        }
+
+        let entity = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url,
+                                          shaders: [TwoPassShader()]).loadEntity()
+        let modelEntities = entity.modelEntitiesInHierarchy
+        #expect(modelEntities.count == 2)
+        #expect(modelEntities.contains { $0.name.hasSuffix("_halo") })
+        // Both passes share the material index, so runtime updates reach them together.
+        #expect(modelEntities.allSatisfy {
+            $0.components[GLTFMaterialIndexComponent.self]?.materialIndex == 0
+        })
+    }
+
+    /// A custom shader whose material makes an animatable state gets that
+    /// per-entity state driven end to end by VRM expression material binds, the
+    /// way MToon does: baseline reads at load, `setColor` accumulation, one
+    /// `prepareFlush()` per change, and `apply(to:)` for every material
+    /// instance rendering the bound glTF material.
+    @Test
+    func testCustomAnimatingShaderIsDrivenByExpressionBinds() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let target = SIMD4<Float>(0, 1, 0, 1)
+        let modified = try TestSupport.modifiedSeedSanExpressions(name: "custom-shader-color-bind") { preset in
+            guard var happy = preset["happy"] as? [String: Any] else {
+                throw VRMError.dataInconsistent("Missing Seed-san happy expression")
+            }
+            happy["materialColorBinds"] = [[
+                "material": 0,
+                "type": "color",
+                "targetValue": [0.0, 1.0, 0.0, 1.0]
+            ]]
+            preset["happy"] = happy
+        }
+
+        final class TintState: VRMAnimatableMaterialState {
+            var currentColor = SIMD4<Float>(1, 1, 1, 1)
+            private(set) var flushCount = 0
+            private(set) var applyCount = 0
+
+            func color(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float>? {
+                type == .color ? currentColor : nil
+            }
+
+            func setColor(_ color: SIMD4<Float>,
+                          for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> Bool {
+                guard type == .color else { return false }
+                currentColor = color
+                return true
+            }
+
+            // Animates the base color only; the rest is left to the material.
+            func prepareFlush() -> Bool {
+                flushCount += 1
+                return true
+            }
+
+            func apply(to material: any Material) -> any Material {
+                applyCount += 1
+                return material
+            }
+        }
+
+        final class TintShader: GLTFMaterialShader {
+            private(set) var createdStates: [(materialIndex: Int, state: TintState)] = []
+
+            func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+                let materialIndex = context.materialIndex
+                return GLTFShadedMaterial(material: UnlitMaterial()) { [weak self] in
+                    let state = TintState()
+                    self?.createdStates.append((materialIndex, state))
+                    return state
+                }
+            }
+        }
+
+        let shader = TintShader()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: [shader]).loadEntity()
+        // Material bindings register while meshes build, before the expression
+        // setup reads its baselines, so the first state per index is the one
+        // the entity holds.
+        let state = try #require(shader.createdStates.first { $0.materialIndex == 0 }?.state)
+        #expect(state.flushCount == 0)
+
+        vrmEntity.setExpression(value: 1, for: .preset(.happy))
+        #expect(state.currentColor.isApproximatelyEqual(to: target))
+        #expect(state.flushCount == 1)
+        #expect(state.applyCount >= 1)
+
+        // Releasing the expression writes the baseline back through the state.
+        vrmEntity.setExpression(value: 0, for: .preset(.happy))
+        #expect(state.currentColor.isApproximatelyEqual(to: SIMD4<Float>(1, 1, 1, 1)))
+        #expect(state.flushCount == 2)
+    }
+
+    /// A state claims values one at a time, so a color-only state does not
+    /// swallow the binds it does not animate: Seed-san's `happy`
+    /// textureTransformBind still reaches material 11.
+    @Test
+    func testUnclaimedBindsFallBackToTheRealityKitMaterial() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        final class ColorOnlyState: VRMAnimatableMaterialState {
+            var currentColor = SIMD4<Float>(1, 1, 1, 1)
+
+            func color(for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> SIMD4<Float>? {
+                type == .color ? currentColor : nil
+            }
+
+            func setColor(_ color: SIMD4<Float>,
+                          for type: VRM1.Expressions.Expression.MaterialColorBind.MaterialColorType) -> Bool {
+                guard type == .color else { return false }
+                currentColor = color
+                return true
+            }
+
+            func apply(to material: any Material) -> any Material { material }
+        }
+
+        final class ColorOnlyShader: GLTFMaterialShader {
+            func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+                GLTFShadedMaterial(material: UnlitMaterial()) { ColorOnlyState() }
+            }
+        }
+
+        let vrmEntity = try VRMEntityLoader(withData: TestSupport.seedSanData,
+                                            shaders: [ColorOnlyShader()]).loadEntity()
+        vrmEntity.setExpression(value: 1, for: .preset(.happy))
+
+        let transforms = vrmEntity.modelEntitiesInHierarchy
+            .filter { $0.components[GLTFMaterialIndexComponent.self]?.materialIndex == 11 }
+            .flatMap { $0.components[ModelComponent.self]?.materials ?? [] }
+            .compactMap { ($0 as? UnlitMaterial)?.textureCoordinateTransform }
+        #expect(!transforms.isEmpty)
+        #expect(transforms.allSatisfy { $0.offset.isApproximatelyEqual(to: SIMD2<Float>(0.25, 0)) })
+    }
+
+    /// A VRM material the chain fails to build renders with the default
+    /// material, and that fallback is what the rest of the load sees: the chain
+    /// is not asked a second time, so the runtime state can never come from a
+    /// material that is not on screen.
+    @Test
+    func testFailedVRMMaterialFallsBackOnceAndCarriesNoAnimatableState() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        /// Animates nothing, so every bindable value keeps falling back to the
+        /// RealityKit material.
+        final class StubState: VRMAnimatableMaterialState {
+            func apply(to material: any Material) -> any Material { material }
+        }
+
+        /// Fails material 0 the first time it is asked and succeeds afterwards,
+        /// the way a shader depending on transient state would.
+        final class FailOnceShader: GLTFMaterialShader {
+            private(set) var callCounts: [Int: Int] = [:]
+
+            func makeMaterial(for context: GLTFMaterialShaderContext) throws -> GLTFShadedMaterial? {
+                let index = context.materialIndex
+                callCounts[index, default: 0] += 1
+                if index == 0, callCounts[index] == 1 {
+                    throw VRMError.notSupported("simulated material failure")
+                }
+                return GLTFShadedMaterial(material: UnlitMaterial()) { StubState() }
+            }
+        }
+
+        let shader = FailOnceShader()
+        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, shaders: [shader])
+        let entity = try loader.loadEntity()
+
+        #expect(shader.callCounts[0] == 1)
+        // The default material, not the UnlitMaterial the retry would build.
+        #expect(try loader.material(withMaterialIndex: 0) is PhysicallyBasedMaterial)
+        #expect(loader.makeAnimatableMaterialState(forMaterialIndex: 0) == nil)
+        #expect(shader.callCounts[0] == 1)
+        // Only the failed material falls back; the rest render through the shader.
+        #expect(try loader.material(withMaterialIndex: 1) is UnlitMaterial)
+        #expect(loader.makeAnimatableMaterialState(forMaterialIndex: 1) != nil)
+        #expect(entity.mtoonParameters(forMaterialIndex: 0) == nil)
+    }
+
+#if !os(visionOS)
+    /// A document that merely *uses* `VRMC_materials_mtoon` renders a material
+    /// MToon cannot build through the rest of the chain, here the built-in
+    /// Unlit path, since the material is authored as MToon.
+    @Test
+    func testUnbuildableMToonMaterialFallsThroughWhenTheExtensionIsOptional() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let loader = try VRMEntityLoader(withData: Self.brokenMToonSeedSanData(isRequired: false))
+        _ = try loader.loadEntity()
+        #expect(try loader.material(withMaterialIndex: 0) is UnlitMaterial)
+    }
+
+    /// A generic glTF load honors `extensionsRequired`: a document that cannot be
+    /// drawn without `VRMC_materials_mtoon` fails the whole load rather than
+    /// rendering an Unlit approximation of the material MToon could not build.
+    @Test
+    func testUnbuildableMToonMaterialFailsTheGLTFLoadWhenTheExtensionIsRequired() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let loader = try GLTFEntityLoader(withData: Self.brokenMToonSeedSanData(isRequired: true))
+        #expect(throws: (any Error).self) {
+            try loader.loadEntity()
+        }
+    }
+
+    /// A VRM keeps rendering whatever this renderer can build, so the same
+    /// document loads: the material MToon could not build falls through to the
+    /// Unlit approximation rather than dropping to the default material.
+    @Test
+    func testUnbuildableRequiredMToonMaterialStillRendersInAVRM() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let loader = try VRMEntityLoader(withData: Self.brokenMToonSeedSanData(isRequired: true))
+        let entity = try loader.loadEntity()
+        #expect(try loader.material(withMaterialIndex: 0) is UnlitMaterial)
+        // The rest of the model still renders as MToon.
+        #expect(TestSupport.hasCustomMaterial(in: entity))
+    }
+
+    /// A document requiring `KHR_texture_transform` while giving *MToon's own*
+    /// textures different transforms asks for a result no path of this renderer
+    /// draws. The loader's check only sees the core glTF material's textures,
+    /// so MToon rejects this one itself.
+    @Test
+    func testRequiredTextureTransformFailsWhenMToonTexturesDisagree() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let modified = try TestSupport.modifiedSeedSanData(name: "mixed-mtoon-texture-transform") { json in
+            json["extensionsRequired"] = (json["extensionsRequired"] as? [String] ?? [])
+                + ["KHR_texture_transform"]
+            guard var materials = json["materials"] as? [[String: Any]],
+                  var extensions = materials.first?["extensions"] as? [String: Any],
+                  var mtoon = extensions["VRMC_materials_mtoon"] as? [String: Any],
+                  var shade = mtoon["shadeMultiplyTexture"] as? [String: Any] else {
+                throw VRMError.dataInconsistent("Missing Seed-san MToon shade texture")
+            }
+            // The core material's textures still agree, so only MToon's own
+            // texture set makes the transforms disagree.
+            shade["extensions"] = ["KHR_texture_transform": ["scale": [2.0, 2.0]]]
+            mtoon["shadeMultiplyTexture"] = shade
+            extensions["VRMC_materials_mtoon"] = mtoon
+            materials[0]["extensions"] = extensions
+            json["materials"] = materials
+        }
+
+        #expect(throws: (any Error).self) {
+            try GLTFEntityLoader(withData: modified).loadEntity()
+        }
+        // The same document renders as a VRM, through the single-transform
+        // approximation MToon logs.
+        #expect(try VRMEntityLoader(withData: modified).material(withMaterialIndex: 0) is CustomMaterial)
+    }
+
+    /// Seed-san with material 0's MToon shade texture pointing past the end of
+    /// the texture array, so building it as MToon fails.
+    private static func brokenMToonSeedSanData(isRequired: Bool) throws -> Data {
+        try TestSupport.modifiedSeedSanData(name: "broken-mtoon-texture-\(isRequired ? "required" : "used")") { json in
+            if isRequired {
+                json["extensionsRequired"] = (json["extensionsRequired"] as? [String] ?? [])
+                    + ["VRMC_materials_mtoon"]
+            }
+            guard var materials = json["materials"] as? [[String: Any]],
+                  var extensions = materials.first?["extensions"] as? [String: Any],
+                  var mtoon = extensions["VRMC_materials_mtoon"] as? [String: Any] else {
+                throw VRMError.dataInconsistent("Missing Seed-san MToon extension")
+            }
+            mtoon["shadeMultiplyTexture"] = ["index": 9999]
+            extensions["VRMC_materials_mtoon"] = mtoon
+            materials[0]["extensions"] = extensions
+            json["materials"] = materials
+        }
+    }
+
+    /// `.convertAll` toon-shades a plain glTF: its PBR material renders through
+    /// the MToon `CustomMaterial`, with the shade color derived from the base
+    /// color and the shade texture reusing the base color texture.
+    @Test
+    func testConvertAllRendersAPlainGLTFMaterialAsMToon() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let style = MToonConversionStyle(shadeColorScale: 0.5)
+        let loader = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url,
+                                          shaders: [MToonShader(source: .convertAll(style))])
+        let material = try #require(try loader.material(withMaterialIndex: 0) as? CustomMaterial,
+                                    TestSupport.expectedCustomMaterialMessage)
+        #expect(material.custom.texture != nil)
+
+        let state = try #require(loader.makeAnimatableMaterialState(forMaterialIndex: 0)
+            as? MToonAnimatableMaterialState)
+        let baseColor = state.parameters.baseColor
+        let expectedShade = SIMD4<Float>(baseColor.x * 0.5, baseColor.y * 0.5, baseColor.z * 0.5, 1)
+        #expect(state.parameters.shadeColor == expectedShade)
+        // The shade side samples the base color texture, so it keeps its detail.
+        #expect(material.roughness.texture != nil)
+    }
+
+    /// `.authoredOnly` (the default) leaves a plain glTF material alone.
+    @Test
+    func testAuthoredOnlyLeavesAPlainGLTFMaterialStandard() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let loader = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url)
+        #expect(try loader.material(withMaterialIndex: 0) is PhysicallyBasedMaterial)
+        #expect(loader.makeAnimatableMaterialState(forMaterialIndex: 0) == nil)
+    }
+
+    /// A converted material with an outline style gets the inverted-hull
+    /// outline entity, like an authored MToon material would.
+    @Test
+    func testConvertAllWithOutlineStyleCreatesOutlineEntities() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let style = MToonConversionStyle(outlineWidthFactor: 0.002)
+        let entity = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url,
+                                          shaders: [MToonShader(source: .convertAll(style))]).loadEntity()
+        // Named after the mesh it belongs to, not after the unnamed model entity.
+        let outline = try #require(entity.modelEntitiesInHierarchy.first { $0.name.hasSuffix("_outline") })
+        let mesh = try #require(outline.parent?.parent)
+        #expect(!mesh.name.isEmpty)
+        #expect(outline.name == "\(mesh.name)_outline")
+        #expect(outline.parent?.name == "\(mesh.name)_container")
+
+        let noOutline = try GLTFEntityLoader(withURL: GLTFSampleAsset.simpleTexture.url,
+                                             shaders: [MToonShader(source: .convertAll)]).loadEntity()
+        #expect(!noOutline.modelEntitiesInHierarchy.contains { $0.name.hasSuffix("_outline") })
+    }
+
+    /// `.convertAll` keeps the authored values of a material that already
+    /// carries MToon data.
+    @Test
+    func testConvertAllKeepsAuthoredMToonMaterials() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        func shadeColor(of loader: GLTFEntityLoader) throws -> SIMD4<Float> {
+            _ = try loader.material(withMaterialIndex: 0)
+            let state = try #require(loader.makeAnimatableMaterialState(forMaterialIndex: 0)
+                as? MToonAnimatableMaterialState)
+            return state.parameters.shadeColor
+        }
+
+        let authored = try VRMEntityLoader(withData: TestSupport.seedSanData,
+                                           shaders: [MToonShader()])
+        let converted = try VRMEntityLoader(withData: TestSupport.seedSanData,
+                                            shaders: [MToonShader(source: .convertAll)])
+        #expect(try shadeColor(of: converted) == shadeColor(of: authored))
+    }
+
+    /// An unreadable MToon material is still MToon, so `.convertAll` leaves it to
+    /// the Unlit approximation rather than inventing toon values over the ones it
+    /// is already authored with.
+    @Test
+    func testConvertAllLeavesUnreadableMToonVersionsAlone() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let futureVersion = try Self.seedSanDataWithMToonSpecVersion("1.1", isRequired: false)
+
+        for source in [MToonShader.Source.authoredOnly, .convertAll] {
+            let loader = try VRMEntityLoader(withData: futureVersion,
+                                             shaders: [MToonShader(source: source)])
+            let entity = try loader.loadEntity()
+            #expect(try loader.material(withMaterialIndex: 0) is UnlitMaterial)
+            #expect(entity.mtoonParameters(forMaterialIndex: 0) == nil)
+            // Only the unreadable material drops out; the rest still convert.
+            #expect(try loader.material(withMaterialIndex: 1) is CustomMaterial,
+                    TestSupport.expectedCustomMaterialMessage)
+        }
+    }
+
+    /// A document that cannot be drawn without `VRMC_materials_mtoon` is not
+    /// drawable through the Unlit approximation either, so an unreadable MToon
+    /// version fails the generic glTF load.
+    @Test
+    func testUnreadableMToonVersionFailsTheGLTFLoadWhenTheExtensionIsRequired() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let required = try Self.seedSanDataWithMToonSpecVersion("1.1", isRequired: true)
+        #expect(throws: (any Error).self) {
+            try GLTFEntityLoader(withData: required).loadEntity()
+        }
+        // A VRM renders with whatever this renderer can build, so the same
+        // document still loads through the Unlit approximation.
+        let vrmLoader = try VRMEntityLoader(withData: required)
+        _ = try vrmLoader.loadEntity()
+        #expect(try vrmLoader.material(withMaterialIndex: 0) is UnlitMaterial)
+    }
+
+    /// Seed-san with material 0's MToon `specVersion` replaced, so its authored
+    /// values cannot be read.
+    private static func seedSanDataWithMToonSpecVersion(_ specVersion: String,
+                                                        isRequired: Bool) throws -> Data {
+        try TestSupport.modifiedSeedSanData(name: "mtoon-spec-\(specVersion)") { json in
+            if isRequired {
+                json["extensionsRequired"] = (json["extensionsRequired"] as? [String] ?? [])
+                    + ["VRMC_materials_mtoon"]
+            }
+            guard var materials = json["materials"] as? [[String: Any]],
+                  var extensions = materials.first?["extensions"] as? [String: Any],
+                  var mtoon = extensions["VRMC_materials_mtoon"] as? [String: Any] else {
+                throw VRMError.dataInconsistent("Missing Seed-san MToon extension")
+            }
+            mtoon["specVersion"] = specVersion
+            extensions["VRMC_materials_mtoon"] = mtoon
+            materials[0]["extensions"] = extensions
+            json["materials"] = materials
+        }
+    }
+
+    /// A VRM material without MToon data, which would fall back to Unlit / PBR
+    /// under the default chain, converts too, and the expression runtime picks
+    /// the converted parameters up.
+    @Test
+    func testConvertAllAppliesToVRMMaterialsWithoutMToonData() throws {
+        guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
+        let stripped = try TestSupport.modifiedSeedSanMaterial(name: "no-mtoon-extension") { material in
+            var extensions = material["extensions"] as? [String: Any] ?? [:]
+            extensions.removeValue(forKey: "VRMC_materials_mtoon")
+            material["extensions"] = extensions
+        }
+
+        let fallbackEntity = try VRMEntityLoader(withData: stripped,
+                                                 shaders: [MToonShader()]).loadEntity()
+        #expect(fallbackEntity.mtoonParameters(forMaterialIndex: 0) == nil)
+
+        let loader = try VRMEntityLoader(withData: stripped,
+                                         shaders: [MToonShader(source: .convertAll)])
+        let convertedEntity = try loader.loadEntity()
+        #expect(try loader.material(withMaterialIndex: 0) is CustomMaterial)
+        #expect(convertedEntity.mtoonParameters(forMaterialIndex: 0) != nil)
+    }
+#endif
+}
+#endif

--- a/Tests/VRMRealityKitTests/TestSupport.swift
+++ b/Tests/VRMRealityKitTests/TestSupport.swift
@@ -26,6 +26,14 @@ enum TestSupport {
         try GLTFEntityLoader(withData: asset.rewritingJSON(modify), rootDirectory: asset.rootDirectory)
     }
 
+    /// The default chain with MToon outlines disabled, for tests that inspect
+    /// materials without outline siblings in the way.
+    @available(iOS 18.0, macOS 15.0, visionOS 2.0, *)
+    @MainActor
+    static var noOutlineShaders: [any GLTFMaterialShader] {
+        [MToonShader(isOutlineEnabled: false)]
+    }
+
     /// The bundled Seed-san VRM 1.0 fixture.
     static var seedSanData: Data { VRMSampleAsset.seedSan.data }
 

--- a/Tests/VRMRealityKitTests/VRM1RealityKitTests.swift
+++ b/Tests/VRMRealityKitTests/VRM1RealityKitTests.swift
@@ -40,7 +40,7 @@ struct VRM1RealityKitTests {
         _ = try #require(defaultMaterial as? CustomMaterial,
                          TestSupport.expectedCustomMaterialMessage)
 
-        let disabledLoader = try VRMEntityLoader(withData: seedSan, isMToonEnabled: false)
+        let disabledLoader = try VRMEntityLoader(withData: seedSan, shaders: [])
         let disabledMaterial = try disabledLoader.material(withMaterialIndex: 0)
         #expect(!(disabledMaterial is CustomMaterial))
         #expect(disabledMaterial is UnlitMaterial)
@@ -92,7 +92,7 @@ struct VRM1RealityKitTests {
             material["normalTexture"] = ["index": 0, "scale": 0.35]
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
         let parameters = try mtoonParameters(in: vrmEntity, materialIndex: 0)
 
@@ -119,7 +119,7 @@ struct VRM1RealityKitTests {
             mtoon["uvAnimationMaskTexture"] = ["index": textureIndex]
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let material = try #require(loader.material(withMaterialIndex: 0) as? CustomMaterial)
         let rawTexture = try loader.texture(withTextureIndex: textureIndex, semantic: .raw)
         let colorTexture = try loader.texture(withTextureIndex: textureIndex, semantic: .color)
@@ -153,7 +153,7 @@ struct VRM1RealityKitTests {
     func testMToonShadeMultiplyTextureFallsBackToWhite() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let modified = try seedSanDataWithNonDefaultEyeSampler()
-        let vrmLoader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let vrmLoader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try vrmLoader.loadEntity()
         let eyeTransparentParameters = try mtoonParameters(in: vrmEntity, materialIndex: 4)
 
@@ -165,7 +165,7 @@ struct VRM1RealityKitTests {
     func testMToonRespectsDoubleSidedMaterialFlag() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let seedSan = TestSupport.seedSanData
-        let singleSidedLoader = try VRMEntityLoader(withData: seedSan, isOutlineEnabled: false)
+        let singleSidedLoader = try VRMEntityLoader(withData: seedSan, shaders: TestSupport.noOutlineShaders)
         let singleSided = try #require(singleSidedLoader.material(withMaterialIndex: 0) as? CustomMaterial)
         #expect(singleSided.faceCulling == .back)
 
@@ -173,7 +173,7 @@ struct VRM1RealityKitTests {
             material["doubleSided"] = true
         }
 
-        let doubleSidedLoader = try VRMEntityLoader(withData: doubleSidedData, isOutlineEnabled: false)
+        let doubleSidedLoader = try VRMEntityLoader(withData: doubleSidedData, shaders: TestSupport.noOutlineShaders)
         let doubleSided = try #require(doubleSidedLoader.material(withMaterialIndex: 0) as? CustomMaterial)
         #expect(doubleSided.faceCulling == .none)
     }
@@ -232,14 +232,14 @@ struct VRM1RealityKitTests {
             material["extensions"] = extensions
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let material = try #require(loader.material(withMaterialIndex: 0) as? CustomMaterial)
-        let transform = try loader.currentTextureTransform(withMaterialIndex: 0)
+        let transform = try #require(loader.makeAnimatableMaterialState(forMaterialIndex: 0)?.textureTransform)
         #expect(transform.offset.isApproximatelyEqual(to: SIMD2<Float>(0.25, 0.5)))
         #expect(transform.scale.isApproximatelyEqual(to: SIMD2<Float>(0.75, 0.5)))
         #expect(transform.rotation.isApproximatelyEqual(to: 0.2))
         // MToon.metal applies the transform from the parameter rows, so the
-        // material-level transform must stay identity — otherwise RealityKit
+        // material-level transform must stay identity, otherwise RealityKit
         // would transform the primary UV a second time.
         #expect(material.textureCoordinateTransform.offset == SIMD2<Float>(0, 0))
         #expect(material.textureCoordinateTransform.scale == SIMD2<Float>(1, 1))
@@ -262,13 +262,13 @@ struct VRM1RealityKitTests {
             mtoon["shadeMultiplyTexture"] = shadeTexture
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         _ = try #require(loader.material(withMaterialIndex: 0) as? CustomMaterial)
 
         // Base color is the first UV-accessed slot, so its identity transform
         // wins; taking the first non-nil transform instead would apply the
         // shade slot's transform to the base color texture.
-        let transform = try loader.currentTextureTransform(withMaterialIndex: 0)
+        let transform = try #require(loader.makeAnimatableMaterialState(forMaterialIndex: 0)?.textureTransform)
         #expect(transform.offset == SIMD2<Float>(0, 0))
         #expect(transform.scale == SIMD2<Float>(1, 1))
         #expect(transform.rotation == 0)
@@ -277,7 +277,7 @@ struct VRM1RealityKitTests {
     @Test
     func testNormalMappedMeshesCarryACompleteTangentBasis() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
-        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         var checkedParts = 0
@@ -308,7 +308,7 @@ struct VRM1RealityKitTests {
     @Test
     func testGeneratedBitangentsFollowTheGLTFUVOrientation() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
-        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         var checkedTriangles = 0
@@ -553,7 +553,7 @@ struct VRM1RealityKitTests {
             json["meshes"] = meshes
         }
 
-        let loader = try VRMEntityLoader(withData: data, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: data, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         var checkedParts = 0
@@ -595,7 +595,7 @@ struct VRM1RealityKitTests {
     func testMToonTextureTransformBindUpdatesParameterTexture() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let seedSan = TestSupport.seedSanData
-        let vrmLoader = try VRMEntityLoader(withData: seedSan, isOutlineEnabled: false)
+        let vrmLoader = try VRMEntityLoader(withData: seedSan, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try vrmLoader.loadEntity()
 
         vrmEntity.setExpression(value: 1, for: .preset(.happy))
@@ -614,7 +614,7 @@ struct VRM1RealityKitTests {
     func testExpressionTextureTransformsAccumulateAndResetIndependently() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let seedSan = TestSupport.seedSanData
-        let loader = try VRMEntityLoader(withData: seedSan, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: seedSan, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         vrmEntity.setExpression(value: 1, for: .preset(.happy))
@@ -667,7 +667,7 @@ struct VRM1RealityKitTests {
             json["materials"] = materials
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
         vrmEntity.setExpression(value: 1, for: .preset(.happy))
         vrmEntity.setExpression(value: 1, for: .preset(.angry))
@@ -780,7 +780,7 @@ struct VRM1RealityKitTests {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         // Seed-san's `relaxed` declares overrideBlink / overrideLookAt = block.
         let vrmEntity = try VRMEntityLoader(withData: TestSupport.seedSanData,
-                                            isOutlineEnabled: false).loadEntity()
+                                            shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpression(value: 1, for: .preset(.blink))
         vrmEntity.setExpression(value: 1, for: .preset(.lookUp))
@@ -814,7 +814,7 @@ struct VRM1RealityKitTests {
             happy["isBinary"] = false
             preset["happy"] = happy
         }
-        let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpressions([.preset(.blink): 1, .preset(.happy): 0.25])
 
@@ -838,7 +838,7 @@ struct VRM1RealityKitTests {
                 preset[name] = expression
             }
         }
-        let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpressions([.preset(.blink): 1, .preset(.happy): 0.5])
         #expect(try #require(morphWeight(in: vrmEntity, targetIndex: 1)).isApproximatelyEqual(to: 0.5))
@@ -867,7 +867,7 @@ struct VRM1RealityKitTests {
             preset["blink"] = blink
             preset["happy"] = happy
         }
-        let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpression(value: 1, for: .preset(.blink))
         #expect(morphWeight(in: vrmEntity, targetIndex: 1) == 1)
@@ -881,7 +881,7 @@ struct VRM1RealityKitTests {
     func testExpressionDoesNotOverrideItsOwnKind() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         // "Like overrideBlink for blink, settings for the same kind are treated
-        // as invalid" — blink must not suppress itself or its own group.
+        // as invalid": blink must not suppress itself or its own group.
         let modified = try TestSupport.modifiedSeedSanExpressions(name: "self-overriding-blink") { preset in
             guard var blink = preset["blink"] as? [String: Any] else {
                 throw VRMError.dataInconsistent("Missing Seed-san blink expression")
@@ -889,7 +889,7 @@ struct VRM1RealityKitTests {
             blink["overrideBlink"] = "block"
             preset["blink"] = blink
         }
-        let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpressions([.preset(.blink): 1, .preset(.blinkLeft): 1])
 
@@ -904,7 +904,7 @@ struct VRM1RealityKitTests {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         // `angry` is binary and carries a textureTransformBind on material 11.
         let vrmEntity = try VRMEntityLoader(withData: TestSupport.seedSanData,
-                                            isOutlineEnabled: false).loadEntity()
+                                            shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpression(value: 0.5, for: .preset(.angry))
         var parameters = try mtoonParameters(in: vrmEntity, materialIndex: 11)
@@ -921,7 +921,7 @@ struct VRM1RealityKitTests {
     func testSetExpressionsAppliesEveryWeightAtOnce() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let vrmEntity = try VRMEntityLoader(withData: TestSupport.seedSanData,
-                                            isOutlineEnabled: false).loadEntity()
+                                            shaders: TestSupport.noOutlineShaders).loadEntity()
 
         vrmEntity.setExpressions([.preset(.happy): 1, .preset(.angry): 1])
 
@@ -953,7 +953,7 @@ struct VRM1RealityKitTests {
             json["samplers"] = samplers
         }
 
-        let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+        let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
         let parameters = try mtoonParameters(in: vrmEntity, materialIndex: 0)
 
         // (wrapS, wrapT, filterIndex, 0): clamp / mirrored repeat, and a
@@ -973,8 +973,8 @@ struct VRM1RealityKitTests {
     @Test
     func testEveryGLTFMinFilterMapsToADistinctSampler() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
-        // glTF's six minFilter values are two independent choices — the
-        // minification texel filter and the filter between mip levels — so each
+        // glTF's six minFilter values are two independent choices, the
+        // minification texel filter and the filter between mip levels, so each
         // has to encode to its own filter index.
         let minFilters: [(raw: Int, minification: MToonSamplerFilter.TexelFilter, mip: MToonSamplerFilter.MipFilter)] = [
             (9728, .nearest, .none),      // NEAREST
@@ -994,7 +994,7 @@ struct VRM1RealityKitTests {
                 samplers[0]["minFilter"] = entry.raw
                 json["samplers"] = samplers
             }
-            let vrmEntity = try VRMEntityLoader(withData: modified, isOutlineEnabled: false).loadEntity()
+            let vrmEntity = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders).loadEntity()
             let parameters = try mtoonParameters(in: vrmEntity, materialIndex: 0)
             let expected = MToonSamplerFilter(magnification: .linear,
                                               minification: entry.minification,
@@ -1022,7 +1022,7 @@ struct VRM1RealityKitTests {
                 extensions["VRMC_materials_mtoon"] = mtoon
                 material["extensions"] = extensions
             }
-            let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+            let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
             return try #require(loader.material(withMaterialIndex: 0) as? CustomMaterial,
                                 TestSupport.expectedCustomMaterialMessage)
         }
@@ -1039,8 +1039,7 @@ struct VRM1RealityKitTests {
     func testUpdateAppliesSpringBonePosesWithoutAFrameOfLag() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let vrmEntity = try VRMEntityLoader(withData: TestSupport.seedSanData,
-                                            isMToonEnabled: false,
-                                            isOutlineEnabled: false).loadEntity()
+                                            shaders: []).loadEntity()
 
         // Rotating a parent bone drags the spring chains, so spring bones write
         // new joint transforms during update().
@@ -1090,7 +1089,7 @@ struct VRM1RealityKitTests {
             scenes.append(first)
             json["scenes"] = scenes
         }
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
 
         let firstScene = try loader.loadEntity(withSceneIndex: 0)
         let secondScene = try loader.loadEntity(withSceneIndex: 1)
@@ -1209,7 +1208,7 @@ struct VRM1RealityKitTests {
             json["extensions"] = extensions
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         // The invalid bind is skipped while the valid one keeps working.
@@ -1227,7 +1226,7 @@ struct VRM1RealityKitTests {
             mtoon["shadeMultiplyTexture"] = ["index": 9999]
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         // The state goes with the material, so no expression bind keeps writing
@@ -1248,7 +1247,7 @@ struct VRM1RealityKitTests {
             material["pbrMetallicRoughness"] = ["baseColorTexture": ["index": 9999]]
         }
 
-        let loader = try VRMEntityLoader(withData: modified, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: modified, shaders: TestSupport.noOutlineShaders)
         let vrmEntity = try loader.loadEntity()
 
         #expect(TestSupport.materialIndexes(in: vrmEntity).contains(0))
@@ -1259,13 +1258,13 @@ struct VRM1RealityKitTests {
     func testFallbackMaterialsDoNotCarryMToonRuntimeState() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
         let seedSan = TestSupport.seedSanData
-        let loader = try VRMEntityLoader(withData: seedSan, isMToonEnabled: false)
+        let loader = try VRMEntityLoader(withData: seedSan, shaders: [])
         let vrmEntity = try loader.loadEntity()
 
         // With MToon disabled, no entity carries MToon runtime state, and
         // expression color binds resolve through the fallback material path.
         #expect(!TestSupport.hasMToonParameters(in: vrmEntity))
-        let fallbackColor = try loader.currentMaterialColor(withMaterialIndex: 0, type: .color)
+        let fallbackColor = try vrmEntity.currentMaterialColor(withMaterialIndex: 0, type: .color, loader: loader)
         let fallbackMaterial = try loader.material(withMaterialIndex: 0)
         #expect(fallbackColor.isApproximatelyEqual(to: fallbackMaterial.currentColor(for: .color)))
     }
@@ -1279,7 +1278,7 @@ struct VRM1RealityKitTests {
 
         // Outlines are the inverted hull only; disabling them must not take the
         // MToon surface shader with them.
-        let noOutlineEntity = try VRMEntityLoader(withData: seedSan, isOutlineEnabled: false).loadEntity()
+        let noOutlineEntity = try VRMEntityLoader(withData: seedSan, shaders: TestSupport.noOutlineShaders).loadEntity()
         #expect(!hasOutlineEntities(in: noOutlineEntity))
         #expect(TestSupport.hasCustomMaterial(in: noOutlineEntity))
     }
@@ -1287,7 +1286,7 @@ struct VRM1RealityKitTests {
     @Test
     func testMToonMaterialsPreserveTheFixtureAlphaModes() throws {
         guard #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) else { return }
-        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, isOutlineEnabled: false)
+        let loader = try VRMEntityLoader(withData: TestSupport.seedSanData, shaders: TestSupport.noOutlineShaders)
         let opaqueMaterial = try #require(loader.material(withMaterialIndex: 0) as? CustomMaterial)
         let blendMaterial = try #require(loader.material(withMaterialIndex: 4) as? CustomMaterial)
 
@@ -1315,8 +1314,7 @@ struct VRM1RealityKitTests {
         let loader = try VRMEntityLoader(withData: TestSupport.seedSanData)
         let material = try loader.material(withMaterialIndex: 0)
 
-        #expect(loader.isMToonEnabled)
-        #expect(loader.isOutlineEnabled)
+        #expect(loader.shaders.contains { $0 is MToonShader })
         #expect(material is UnlitMaterial || material is PhysicallyBasedMaterial)
     }
 #endif

--- a/Tests/VRMTestSupport/GLBRewriter.swift
+++ b/Tests/VRMTestSupport/GLBRewriter.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Rewrites the JSON chunk of a GLB in memory.
 ///
-/// Every test target needs the same thing — take a bundled `.vrm`, change a few
-/// fields, and hand the result straight to a loader — so the chunk walking and
+/// Every test target needs the same thing: take a bundled `.vrm`, change a few
+/// fields, and hand the result straight to a loader. So the chunk walking and
 /// header rebuilding live here rather than once per target.
 public enum GLBRewriter {
     public enum Error: Swift.Error {


### PR DESCRIPTION
## Summary

Adds custom material shader support to VRMRealityKit.

## Changes

* Added a material shader chain to `GLTFEntityLoader` and `VRMEntityLoader`.
* Refactored MToon rendering to use the new shader architecture.
* Added support for custom shaders and MToon conversion for standard glTF materials.
* Generalized animatable material state and additional render passes.
* Updated examples, documentation, and tests for the new API.

## Breaking Changes

The previous `isMToonEnabled` / `isOutlineEnabled` loader options are replaced by the new `shaders` configuration.